### PR TITLE
Update UARTE30 allowed GPIO to P0* for nrf54l MCUs

### DIFF
--- a/mcus/nrf54l05/qfn40-5x5-qdaa.json
+++ b/mcus/nrf54l05/qfn40-5x5-qdaa.json
@@ -1373,23 +1373,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },

--- a/mcus/nrf54l05/qfn48-6x6-qfaa.json
+++ b/mcus/nrf54l05/qfn48-6x6-qfaa.json
@@ -1531,23 +1531,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },

--- a/mcus/nrf54l05/qfn52-6x6-qgaa.json
+++ b/mcus/nrf54l05/qfn52-6x6-qgaa.json
@@ -1573,23 +1573,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },

--- a/mcus/nrf54l10/qfn40-5x5-qdaa.json
+++ b/mcus/nrf54l10/qfn40-5x5-qdaa.json
@@ -1373,23 +1373,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },

--- a/mcus/nrf54l10/qfn48-6x6-qfaa.json
+++ b/mcus/nrf54l10/qfn48-6x6-qfaa.json
@@ -1531,23 +1531,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },

--- a/mcus/nrf54l10/qfn52-6x6-qgaa.json
+++ b/mcus/nrf54l10/qfn52-6x6-qgaa.json
@@ -1573,23 +1573,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },

--- a/mcus/nrf54l15/qfn40-5x5-qdaa.json
+++ b/mcus/nrf54l15/qfn40-5x5-qdaa.json
@@ -1373,23 +1373,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },

--- a/mcus/nrf54l15/qfn48-6x6-qfaa.json
+++ b/mcus/nrf54l15/qfn48-6x6-qfaa.json
@@ -1531,23 +1531,23 @@
           "name": "TXD",
           "direction": "output",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RXD",
           "direction": "input",
           "isMandatory": true,
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "CTS",
           "direction": "output",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         },
         {
           "name": "RTS",
           "direction": "input",
-          "allowedGpio": ["P1*"]
+          "allowedGpio": ["P0*"]
         }
       ]
     },


### PR DESCRIPTION
Changed the allowedGpio field for UARTE30 signals (TXD, RXD, CTS, RTS) from ["P1*"] to ["P0*"] in all QFN package JSON files for nrf54l05, nrf54l10, and nrf54l15 MCUs to reflect correct pin mapping.