### PR TITLE
Refine pin filtering logic in getPinsForSignal

### DIFF
--- a/script.js
+++ b/script.js
@@ -866,7 +866,7 @@ function updateModalPinAvailability() {
 function getPinsForSignal(signal) {
   if (!mcuData.pins) return [];
   return mcuData.pins.filter((pin) => {
-    if (pin.defaultType !== "io") return false;
+    if (!Array.isArray(pin.functions) || !pin.functions.includes("Digital I/O")) return false;
     if (signal.requiresClockCapablePin && !pin.isClockCapable) return false;
     return signal.allowedGpio.some((allowed) =>
       allowed.endsWith("*")


### PR DESCRIPTION
Fixes #1 - Updated getPinsForSignal to filter pins based on the presence of 'Digital I/O' in pin.functions instead of checking pin.defaultType. This ensures more accurate selection of pins for signals requiring digital I/O functionality.
