### PR TITLE
Comment out .pin.crystal-lf selector in CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -496,7 +496,7 @@ button:hover,
 .pin.power-ground,
 .pin.debug,
 .pin.crystal-hf,
-.pin.crystal-lf,
+/* .pin.crystal-lf, */
 .pin.rf-antenna {
   background-color: var(--pin-bg-special);
   color: white;


### PR DESCRIPTION
The .pin.crystal-lf selector was commented out from the special pin background styling. This allows the lfxo pins to be shown as used when the Low Frequency Crystal Oscillator check box is checked (as per the NFC pins). If this is not intended behaviour, please reject. 