### PR TITLE
fix: enable NFC pins if not being used as NFC

### DIFF
--- a/script.js
+++ b/script.js
@@ -1938,6 +1938,21 @@ function generateCommonDtsi(mcu) {
     content += generatePeripheralNode(p, template);
   });
 
+  // Check if NFC pins are not being used as NFC
+  let nfcUsed = false;
+  selectedPeripherals.forEach((p) => {
+    const template = deviceTreeTemplates[p.id];
+    if (template && template.type == "NFCT") {
+      nfcUsed = true;
+    }
+  });
+  if (!nfcUsed) {
+    content += `&uicr {
+\tnfct-pins-as-gpios;
+};
+`
+  }
+
   return content;
 }
 


### PR DESCRIPTION
While support was added to use NFC pins as GPIO in #3 , for them to work it is needed to set the right config in the [PADCONFIG registers](https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/nfct.html#register.PADCONFIG), which as I understand can be done by setting the right value in the [UICR](https://github.com/nrfconnect/sdk-zephyr/blob/cefb2ed86ac723218c509ef7ceae2509bb1f89f6/dts/bindings/arm/nordic%2Cnrf-uicr.yaml#L11-L21) (disabling the NFC is not enough, documentation is not clear, though).

This implementation always sets the NFC as GPIO if they are not used, however, I don't think this is the best solution, as per documentation:

> [...] and some increased leakage current between the two pins is to be expected if they are used in GPIO mode [...]

So it would be a better solution to enable them as GPIO only if they are used as so (no if they are not used as NFC), but I don't really understand the code or where should I change it to do like said, so guidelines/changes are appreciated