### PR TITLE
Add Nordic PMIC configuration support

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,20 @@
         </div>
       </header>
 
+      <button
+        type="button"
+        id="pmicFeatureCallout"
+        class="pmic-feature-callout"
+      >
+        <span class="pmic-feature-text">
+          <strong>NEW: Add a PMIC!</strong>
+          <span
+            >Fuel gauges, regulators, and smart system management features for
+            primary cell or rechargeable batteries!</span
+          >
+        </span>
+      </button>
+
       <div class="content-grid">
         <aside class="sidebar">
           <div class="package-selector card">
@@ -120,6 +134,7 @@
           <div class="sidebar-content card">
             <h2>Peripherals</h2>
             <div id="content-peripherals">
+              <div id="pmicPanel" class="pmic-panel"></div>
               <input
                 type="text"
                 id="searchPeripherals"
@@ -608,6 +623,21 @@
         <div class="modal-footer">
           <button id="cancelImportExport">Cancel</button>
           <button id="confirmImportExport">Export</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- PMIC Configuration Modal -->
+    <div id="pmicConfigModal" class="modal">
+      <div class="modal-content pmic-modal-content">
+        <div class="modal-header">
+          <h2 id="pmicModalTitle">Configure PMIC</h2>
+          <span class="close" id="closePmicModal">&times;</span>
+        </div>
+        <div id="pmicModalBody"></div>
+        <div class="modal-footer">
+          <button id="cancelPmicConfig">Cancel</button>
+          <button id="confirmPmicConfig">Save PMIC</button>
         </div>
       </div>
     </div>

--- a/js/devicetree.js
+++ b/js/devicetree.js
@@ -6,6 +6,7 @@ import {
   getMcuSupportsFLPRXIP as getMcuSupportsFLPRXIPFromManifest,
   getMcuSupportsNonSecure as getMcuSupportsNonSecureFromManifest,
 } from "./mcu-manifest.js";
+import { getPmicDefinition, isNpm13xx } from "./pmic-data.js";
 import { parsePinName } from "./utils.js";
 
 export function getMcuSupportsNonSecure(mcuId) {
@@ -173,6 +174,421 @@ function getConsoleRoutingComment(mcu) {
   }
 
   return formatCommentBlock(note);
+}
+
+function getPmic() {
+  const definition = getPmicDefinition(state.pmicConfig?.id);
+  if (!definition) return null;
+
+  return {
+    config: state.pmicConfig,
+    definition,
+  };
+}
+
+export function generatePmicIncludes() {
+  const pmic = getPmic();
+  if (!pmic) return "";
+
+  const regulatorHeader = isNpm13xx(pmic.definition) ? "npm13xx" : "npm2100";
+  return `#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/regulator/${regulatorHeader}.h>
+
+`;
+}
+
+function getPmicLabelPrefix(definition) {
+  return definition.id;
+}
+
+function getPmicI2cNodeName(config) {
+  return (
+    state.deviceTreeTemplates?.[config.i2cPeripheralId]?.dtNodeName || null
+  );
+}
+
+function toDtGpioFlag(activeState) {
+  return activeState === "active-low" ? "GPIO_ACTIVE_LOW" : "GPIO_ACTIVE_HIGH";
+}
+
+function gpioSpec(pinName, activeState = "active-high") {
+  const pinInfo = parsePinName(pinName);
+  if (!pinInfo) return null;
+
+  return `<&gpio${pinInfo.port} ${pinInfo.pin} ${toDtGpioFlag(activeState)}>`;
+}
+
+function enabledDvsGpios(config) {
+  return Object.entries(config.dvsGpios || {})
+    .filter(([, entry]) => entry.enabled && entry.hostPin)
+    .sort(([a], [b]) => Number(a) - Number(b));
+}
+
+function usesPmicGpioPhandle(definition, config) {
+  if (isNpm13xx(definition)) return false;
+
+  return Object.values(config.regulators || {}).some(
+    (regulator) => regulator.gpioControl?.mode?.enabled,
+  );
+}
+
+function npm13xxModeConstant(regulator, regulatorConfig) {
+  if (regulator.kind === "buck") {
+    const modes = {
+      auto: "NPM13XX_BUCK_MODE_AUTO",
+      pwm: "NPM13XX_BUCK_MODE_PWM",
+      pfm: "NPM13XX_BUCK_MODE_PFM",
+    };
+    return modes[regulatorConfig.mode] || modes.auto;
+  }
+
+  if (regulator.kind === "ldo") {
+    return regulatorConfig.mode === "ldsw"
+      ? "NPM13XX_LDSW_MODE_LDSW"
+      : "NPM13XX_LDSW_MODE_LDO";
+  }
+
+  return null;
+}
+
+function npm2100BoostModeConstant(regulatorConfig) {
+  const modes = {
+    auto: "NPM2100_REG_OPER_AUTO",
+    hp: "NPM2100_REG_OPER_HP",
+    lp: "NPM2100_REG_OPER_LP",
+    pass: "NPM2100_REG_OPER_PASS",
+    nohp: "NPM2100_REG_OPER_NOHP",
+  };
+  const parts = [modes[regulatorConfig.mode] || modes.auto];
+  const control = regulatorConfig.gpioControl?.mode;
+
+  if (control?.enabled) {
+    const forced = {
+      hp: "NPM2100_REG_FORCE_HP",
+      lp: "NPM2100_REG_FORCE_LP",
+      pass: "NPM2100_REG_FORCE_PASS",
+      nohp: "NPM2100_REG_FORCE_NOHP",
+    };
+    if (forced[control.forcedMode]) {
+      parts.push(forced[control.forcedMode]);
+    }
+  }
+
+  return parts.join(" | ");
+}
+
+function npm2100LdoswModeConstant(regulatorConfig) {
+  const loadSwitch = regulatorConfig.mode?.startsWith("ldsw");
+  const control = regulatorConfig.gpioControl?.mode;
+  const parts = [];
+
+  if (loadSwitch) {
+    parts.push("NPM2100_REG_LDSW_EN");
+  }
+
+  if (control?.enabled) {
+    if (control.forcedMode === "ulp") {
+      parts.push("NPM2100_REG_OPER_OFF", "NPM2100_REG_FORCE_ULP");
+    } else if (regulatorConfig.mode?.endsWith("ulp")) {
+      parts.push("NPM2100_REG_OPER_ULP", "NPM2100_REG_FORCE_HP");
+    } else {
+      parts.push("NPM2100_REG_OPER_OFF", "NPM2100_REG_FORCE_HP");
+    }
+    return parts.join(" | ");
+  }
+
+  const modeMap = {
+    "ldo-auto": "NPM2100_REG_OPER_AUTO",
+    auto: "NPM2100_REG_OPER_AUTO",
+    "ldo-hp": "NPM2100_REG_OPER_HP",
+    "ldo-ulp": "NPM2100_REG_OPER_ULP",
+    "ldsw-auto": "NPM2100_REG_OPER_AUTO",
+    "ldsw-hp": "NPM2100_REG_OPER_HP",
+    "ldsw-ulp": "NPM2100_REG_OPER_ULP",
+  };
+  parts.push(modeMap[regulatorConfig.mode] || "NPM2100_REG_OPER_AUTO");
+
+  return parts.join(" | ");
+}
+
+function regulatorModeConstant(definition, regulator, regulatorConfig) {
+  if (isNpm13xx(definition)) {
+    return npm13xxModeConstant(regulator, regulatorConfig);
+  }
+
+  if (regulator.kind === "boost") {
+    return npm2100BoostModeConstant(regulatorConfig);
+  }
+
+  if (regulator.kind === "ldosw") {
+    return npm2100LdoswModeConstant(regulatorConfig);
+  }
+
+  return null;
+}
+
+function generatePmicGpioNode(definition, config, prefix) {
+  if (
+    !config.gpioController?.enabled &&
+    !usesPmicGpioPhandle(definition, config)
+  ) {
+    return "";
+  }
+
+  return `
+\t\t${prefix}_gpio: gpio-controller {
+\t\t\tcompatible = "nordic,${definition.id}-gpio";
+\t\t\tgpio-controller;
+\t\t\t#gpio-cells = <2>;
+\t\t\tngpios = <${definition.gpioCount}>;
+\t\t};
+`;
+}
+
+function generatePmicDvsGpios(config) {
+  const entries = enabledDvsGpios(config)
+    .map(([, entry]) => gpioSpec(entry.hostPin, entry.activeState))
+    .filter(Boolean);
+
+  if (entries.length === 0) return "";
+  if (entries.length === 1) {
+    return `\t\t\tdvs-gpios = ${entries[0]};\n`;
+  }
+
+  return `\t\t\tdvs-gpios = ${entries.join(",\n\t\t\t            ")};\n`;
+}
+
+function generateNpm13xxRegulatorControl(
+  regulatorConfig,
+  controlName,
+  property,
+) {
+  const control = regulatorConfig.gpioControl?.[controlName];
+  if (!control?.enabled || control.pmicGpio === "") return "";
+
+  return `\t\t\t\t${property} = <${control.pmicGpio} ${toDtGpioFlag(control.activeState)}>;\n`;
+}
+
+function generateNpm2100ModeGpio(regulatorConfig, prefix) {
+  const control = regulatorConfig.gpioControl?.mode;
+  if (!control?.enabled || control.pmicGpio === "") return "";
+
+  return `\t\t\t\tmode-gpios = <&${prefix}_gpio ${control.pmicGpio} ${toDtGpioFlag(control.activeState)}>;\n`;
+}
+
+function generatePmicRegulatorChild(
+  definition,
+  regulator,
+  regulatorConfig,
+  prefix,
+) {
+  const range =
+    definition.id === "npm2100"
+      ? definition.regulatorVoltage[regulator.id]
+      : definition.regulatorVoltage;
+  const label = `${prefix}_${regulator.id.toLowerCase()}`;
+  const mode = regulatorModeConstant(definition, regulator, regulatorConfig);
+
+  let content = `\t\t\t${label}: ${regulator.id} {\n`;
+  content += `\t\t\t\tregulator-min-microvolt = <${range.min}>;\n`;
+  content += `\t\t\t\tregulator-max-microvolt = <${range.max}>;\n`;
+  content += `\t\t\t\tregulator-init-microvolt = <${regulatorConfig.voltageMicrovolt}>;\n`;
+
+  if (regulatorConfig.enabled) {
+    if (regulatorConfig.boot === "always-on") {
+      content += "\t\t\t\tregulator-always-on;\n";
+    } else if (regulatorConfig.boot === "boot-on") {
+      content += "\t\t\t\tregulator-boot-on;\n";
+    }
+  } else if (isNpm13xx(definition)) {
+    content += "\t\t\t\tregulator-boot-off;\n";
+  }
+
+  if (mode) {
+    const modeExpression = mode.includes("|") ? `(${mode})` : mode;
+    content += `\t\t\t\tregulator-initial-mode = <${modeExpression}>;\n`;
+  }
+
+  if (isNpm13xx(definition)) {
+    if (regulatorConfig.activeDischarge) {
+      content += "\t\t\t\tactive-discharge;\n";
+    }
+    content += generateNpm13xxRegulatorControl(
+      regulatorConfig,
+      "enable",
+      "enable-gpio-config",
+    );
+    if (regulator.kind === "buck") {
+      content += generateNpm13xxRegulatorControl(
+        regulatorConfig,
+        "pwm",
+        "pwm-gpio-config",
+      );
+      content += generateNpm13xxRegulatorControl(
+        regulatorConfig,
+        "retention",
+        "retention-gpio-config",
+      );
+    }
+  } else {
+    content += generateNpm2100ModeGpio(regulatorConfig, prefix);
+  }
+
+  content += "\t\t\t};\n";
+  return content;
+}
+
+function generatePmicRegulators(definition, config, prefix) {
+  let content = `
+\t\t${prefix}_regulators: regulators {
+\t\t\tcompatible = "nordic,${definition.id}-regulator";
+`;
+  content += generatePmicDvsGpios(config);
+  content += "\n";
+
+  definition.regulators.forEach((regulator) => {
+    content += generatePmicRegulatorChild(
+      definition,
+      regulator,
+      config.regulators[regulator.id],
+      prefix,
+    );
+    content += "\n";
+  });
+
+  content = content.trimEnd();
+  content += `
+\t\t};
+`;
+  return content;
+}
+
+function generatePmicCharger(definition, config, prefix) {
+  if (!isNpm13xx(definition) || !config.charger?.enabled) return "";
+
+  const charger = config.charger;
+  let content = `
+\t\t${prefix}_charger: charger {
+\t\t\tcompatible = "nordic,${definition.id}-charger";
+\t\t\tterm-microvolt = <${charger.termMicrovolt}>;
+\t\t\tcurrent-microamp = <${charger.currentMicroamp}>;
+\t\t\tdischg-limit-microamp = <${charger.dischargeLimitMicroamp}>;
+\t\t\tvbus-limit-microamp = <${charger.vbusLimitMicroamp}>;
+\t\t\tthermistor-ohms = <${charger.thermistorOhms}>;
+\t\t\tthermistor-beta = <${charger.thermistorBeta}>;
+\t\t\tterm-current-percent = <${charger.termCurrentPercent}>;
+`;
+  if (charger.chargingEnable) {
+    content += "\t\t\tcharging-enable;\n";
+  }
+  content += "\t\t};\n";
+  return content;
+}
+
+function generatePmicLeds(definition, config, prefix) {
+  if (!isNpm13xx(definition) || !config.leds?.enabled) return "";
+
+  return `
+\t\t${prefix}_leds: leds {
+\t\t\tcompatible = "nordic,${definition.id}-led";
+\t\t\tnordic,led0-mode = "${config.leds.modes.led0}";
+\t\t\tnordic,led1-mode = "${config.leds.modes.led1}";
+\t\t\tnordic,led2-mode = "${config.leds.modes.led2}";
+\t\t};
+`;
+}
+
+function generatePmicWatchdog(definition, config, prefix) {
+  if (!config.watchdog?.enabled) return "";
+
+  return `
+\t\t${prefix}_wdt: watchdog {
+\t\t\tcompatible = "nordic,${definition.id}-wdt";
+\t\t};
+`;
+}
+
+function generatePmicFuelGaugeSensor(definition, config, prefix) {
+  if (definition.id !== "npm2100" || !config.fuelGauge?.enabled) return "";
+
+  return `
+\t\t${prefix}_vbat: vbat {
+\t\t\tcompatible = "nordic,npm2100-vbat";
+\t\t};
+`;
+}
+
+export function generatePmicNode() {
+  const pmic = getPmic();
+  if (!pmic) return "";
+
+  const { config, definition } = pmic;
+  const i2cNodeName = getPmicI2cNodeName(config);
+  if (!i2cNodeName) {
+    return "\n/* PMIC omitted: selected I2C peripheral has no DeviceTree template. */\n";
+  }
+
+  const prefix = getPmicLabelPrefix(definition);
+  const hostInt = config.hostInterrupt?.enabled
+    ? gpioSpec(config.hostInterrupt.hostPin, config.hostInterrupt.activeState)
+    : null;
+
+  let content = `
+&${i2cNodeName} {
+\t${prefix}_pmic: pmic@${definition.address.replace("0x", "")} {
+\t\tcompatible = "nordic,${definition.id}";
+\t\treg = <${definition.address}>;
+`;
+
+  if (hostInt) {
+    content += `\t\thost-int-gpios = ${hostInt};\n`;
+    content += `\t\tpmic-int-pin = <${config.hostInterrupt.pmicPin}>;\n`;
+  }
+
+  content += generatePmicGpioNode(definition, config, prefix);
+  content += generatePmicRegulators(definition, config, prefix);
+  content += generatePmicCharger(definition, config, prefix);
+  content += generatePmicLeds(definition, config, prefix);
+  content += generatePmicWatchdog(definition, config, prefix);
+  content += generatePmicFuelGaugeSensor(definition, config, prefix);
+  content += "\t};\n};\n";
+
+  return content;
+}
+
+function generatePmicDefconfig() {
+  const pmic = getPmic();
+  if (!pmic) return "";
+
+  const { config, definition } = pmic;
+  const sensorEnabled =
+    (isNpm13xx(definition) && config.charger?.enabled) ||
+    (definition.id === "npm2100" && config.fuelGauge?.enabled);
+
+  let content = `
+# Enable PMIC support
+CONFIG_I2C=y
+CONFIG_MFD=y
+CONFIG_REGULATOR=y
+`;
+
+  if (
+    config.gpioController?.enabled ||
+    usesPmicGpioPhandle(definition, config)
+  ) {
+    content += "CONFIG_GPIO=y\n";
+  }
+  if (sensorEnabled) {
+    content += "CONFIG_SENSOR=y\n";
+  }
+  if (isNpm13xx(definition) && config.leds?.enabled) {
+    content += "CONFIG_LED=y\n";
+  }
+  if (config.watchdog?.enabled) {
+    content += "CONFIG_WATCHDOG=y\n";
+  }
+
+  return `${content}\n`;
 }
 
 // Helper: get the DT node name for the exported board console UART
@@ -383,6 +799,7 @@ export function generateCommonDtsi(mcu) {
  * SPDX-License-Identifier: Apache-2.0
  */
 
+${generatePmicIncludes()}
 #include "${state.boardInfo.name}_${mcu}-pinctrl.dtsi"
 
 `;
@@ -419,6 +836,8 @@ export function generateCommonDtsi(mcu) {
   if (gpioPins.length > 0) {
     content += generateGpioNodes(gpioPins);
   }
+
+  content += generatePmicNode();
 
   return content;
 }
@@ -659,6 +1078,22 @@ export function generateYamlCapabilities(mcu, isNonSecure) {
 
   supportedFeatures.add("gpio");
   supportedFeatures.add("watchdog");
+  if (state.pmicConfig) {
+    supportedFeatures.add("i2c");
+    supportedFeatures.add("mfd");
+    supportedFeatures.add("regulator");
+
+    const pmicDefinition = getPmicDefinition(state.pmicConfig.id);
+    if (
+      (isNpm13xx(pmicDefinition) && state.pmicConfig.charger?.enabled) ||
+      (pmicDefinition?.id === "npm2100" && state.pmicConfig.fuelGauge?.enabled)
+    ) {
+      supportedFeatures.add("sensor");
+    }
+    if (isNpm13xx(pmicDefinition) && state.pmicConfig.leds?.enabled) {
+      supportedFeatures.add("led");
+    }
+  }
 
   const featuresArray = Array.from(supportedFeatures).sort();
 
@@ -841,7 +1276,7 @@ CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
     }
   }
 
-  return config;
+  return config + generatePmicDefconfig();
 }
 
 export function generateNSDts(mcu) {
@@ -1203,7 +1638,7 @@ CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL=y
 `;
   }
 
-  return config;
+  return config + generatePmicDefconfig();
 }
 
 export function generateBoardYml(mcu, supportsNS, supportsFLPR) {
@@ -1458,6 +1893,77 @@ config BOARD_${boardNameUpper}
   return content;
 }
 
+function getPmicFuelGaugeModel(definition, config) {
+  return definition.fuelGaugeModels?.options.find(
+    (model) => model.id === config.fuelGauge?.model,
+  );
+}
+
+function formatPmicRegulators(definition, config) {
+  return definition.regulators
+    .filter((regulator) => config.regulators?.[regulator.id]?.enabled)
+    .map((regulator) => {
+      const regulatorConfig = config.regulators[regulator.id];
+      const volts = (regulatorConfig.voltageMicrovolt / 1000000).toFixed(2);
+      return `${regulator.label} ${volts} V (${regulatorConfig.mode})`;
+    })
+    .join(", ");
+}
+
+function formatPmicDvsGpios(config) {
+  const entries = enabledDvsGpios(config).map(
+    ([channel, entry], index) =>
+      `PMIC GPIO${channel} on ${entry.hostPin} (${entry.activeState}, DVS bit ${index})`,
+  );
+  return entries.length > 0 ? entries.join(", ") : "none";
+}
+
+function generatePmicReadmeSection() {
+  const pmic = getPmic();
+  if (!pmic) return "";
+
+  const { definition, config } = pmic;
+  const fuelGaugeModel = getPmicFuelGaugeModel(definition, config);
+  const i2cPins = Object.entries(config.i2cPinFunctions || {})
+    .map(([pin, signal]) => `${signal}: ${pin}`)
+    .join(", ");
+  const regulators = formatPmicRegulators(definition, config) || "none enabled";
+
+  let section = `
+## PMIC
+
+- **Part:** ${definition.name} (${config.packageVariant}, \`${definition.compatible}\`, I2C address \`${definition.address}\`)
+- **I2C:** ${config.i2cPeripheralId}${i2cPins ? ` (${i2cPins})` : ""}
+- **Regulators:** ${regulators}
+- **Regulator GPIO control:** ${formatPmicDvsGpios(config)}
+- **Fuel gauge:** ${
+    config.fuelGauge?.enabled ? fuelGaugeModel?.label || "enabled" : "disabled"
+  }
+`;
+
+  if (definition.id === "npm2100" && config.fuelGauge?.enabled) {
+    section += `- **Fuel-gauge model source:** include \`${fuelGaugeModel?.include || "battery_models/primary_cell/<model>.inc"}\` from \`nrfxlib/nrf_fuel_gauge/include\`. The nPM2100 fuel-gauge sample exposes this as \`${fuelGaugeModel?.kconfig || "CONFIG_BATTERY_MODEL_*"}\`; those battery-model Kconfig symbols are sample-level choices, so mirror the selected include/model in your application.
+`;
+  } else if (isNpm13xx(definition) && config.fuelGauge?.enabled) {
+    const modelDetail =
+      fuelGaugeModel?.detail ||
+      "Generate a production Li-ion/Li-poly model with nPM PowerUP.";
+    section += `- **Fuel-gauge model source:** ${modelDetail} Use \`CONFIG_NRF_FUEL_GAUGE_VARIANT_SECONDARY_CELL=y\` in applications using the nRF Fuel Gauge library.
+`;
+  }
+
+  if (config.fuelGauge?.enabled) {
+    section += `- **Application Kconfig hint:** enable \`CONFIG_NRF_FUEL_GAUGE=y\` and ${
+      definition.id === "npm2100"
+        ? "`CONFIG_NRF_FUEL_GAUGE_VARIANT_PRIMARY_CELL=y`"
+        : "`CONFIG_NRF_FUEL_GAUGE_VARIANT_SECONDARY_CELL=y`"
+    } when your application uses the nRF Fuel Gauge library.
+`;
+  }
+
+  return section;
+}
+
 export function generateReadme(mcu, pkg, supportsNS, supportsFLPR) {
   const hasSpiDcxSelection = state.selectedPeripherals.some((p) =>
     Object.values(p.pinFunctions || {}).includes("DCX"),
@@ -1539,6 +2045,7 @@ ${state.boardInfo.revision ? `**Revision:** ${state.boardInfo.revision}\n` : ""}
 ## Selected Peripherals
 
 ${state.selectedPeripherals
+  .filter((p) => p.config?.pmicOwned !== true)
   .map((p) => {
     if (p.config) {
       const capLabel =
@@ -1571,6 +2078,7 @@ ${state.selectedPeripherals
     }
   })
   .join("\n")}
+${generatePmicReadmeSection()}
 
 ## Pin Configuration
 

--- a/js/devkit-loader.js
+++ b/js/devkit-loader.js
@@ -8,6 +8,7 @@ import { updatePinDisplay } from "./pin-layout.js";
 import { updateSelectedPeripheralsList } from "./ui/selected-list.js";
 import { updateConsoleConfig } from "./console-config.js";
 import { showToast } from "./ui/notifications.js";
+import { renderPmicPanel } from "./pmic.js";
 
 export async function loadDevkitConfig(boardName) {
   if (!boardName) {
@@ -133,6 +134,7 @@ function applyDevkitConfig(devkitData) {
   }
 
   organizePeripherals();
+  renderPmicPanel();
   updateSelectedPeripheralsList();
   updatePinDisplay();
   updateConsoleConfig();

--- a/js/export.js
+++ b/js/export.js
@@ -25,6 +25,8 @@ import {
   generateFLPRXIPDts,
   generatePinctrlForPeripheral,
   generatePeripheralNode,
+  generatePmicIncludes,
+  generatePmicNode,
 } from "./devicetree.js";
 import { getDevicetreeExportUnsupportedReason } from "./mcu-manifest.js";
 import { parsePinName } from "./utils.js";
@@ -348,6 +350,7 @@ function exportOverlay() {
  * definition based on your hardware design.
  */
 
+${generatePmicIncludes()}
 `;
 
   // Generate overlay nodes for peripherals that differ from devkit base
@@ -367,6 +370,8 @@ function exportOverlay() {
       }
     }
   });
+
+  overlayContent += generatePmicNode();
 
   // Check if we need a pinctrl overlay
   let pinctrlContent = "";

--- a/js/main.js
+++ b/js/main.js
@@ -39,6 +39,12 @@ import { organizePeripherals } from "./peripherals.js";
 import { updatePinDisplay } from "./pin-layout.js";
 import { updateSelectedPeripheralsList } from "./ui/selected-list.js";
 import { updateConsoleConfig } from "./console-config.js";
+import {
+  closePmicModal,
+  confirmPmicConfig,
+  openPmicModal,
+  renderPmicPanel,
+} from "./pmic.js";
 
 document.addEventListener("DOMContentLoaded", function () {
   // Set up event listeners
@@ -84,6 +90,18 @@ document.addEventListener("DOMContentLoaded", function () {
   document
     .getElementById("confirmOscillatorConfig")
     .addEventListener("click", confirmOscillatorConfig);
+  document
+    .getElementById("closePmicModal")
+    .addEventListener("click", closePmicModal);
+  document
+    .getElementById("cancelPmicConfig")
+    .addEventListener("click", closePmicModal);
+  document
+    .getElementById("confirmPmicConfig")
+    .addEventListener("click", confirmPmicConfig);
+  document
+    .getElementById("pmicFeatureCallout")
+    .addEventListener("click", () => openPmicModal());
 
   // Import/Export config listeners
   document
@@ -197,6 +215,7 @@ function clearAllPeripherals() {
   }
   resetState();
   organizePeripherals();
+  renderPmicPanel();
   updateSelectedPeripheralsList();
   updatePinDisplay();
   updateConsoleConfig();

--- a/js/mcu-loader.js
+++ b/js/mcu-loader.js
@@ -17,6 +17,7 @@ import { createPinLayout, updatePinDisplay } from "./pin-layout.js";
 import { updateSelectedPeripheralsList } from "./ui/selected-list.js";
 import { updateConsoleConfig } from "./console-config.js";
 import { updateExportButtonState } from "./export.js";
+import { renderPmicPanel } from "./pmic.js";
 
 function mergePackageData(baseData, overrideData) {
   const merged = {
@@ -251,6 +252,7 @@ export function reinitializeView(clearOnly = false) {
   if (clearOnly || !state.mcuData.partInfo) {
     document.getElementById("chipTitleDisplay").textContent = "No MCU Loaded";
     organizePeripherals();
+    renderPmicPanel();
     createPinLayout();
     updateSelectedPeripheralsList();
     updatePinDisplay();
@@ -292,6 +294,7 @@ export function reinitializeView(clearOnly = false) {
   }
 
   organizePeripherals();
+  renderPmicPanel();
   updateSelectedPeripheralsList();
   updatePinDisplay();
   updateConsoleConfig();

--- a/js/peripherals.js
+++ b/js/peripherals.js
@@ -334,6 +334,11 @@ export function removePeripheral(id) {
   if (index === -1) return;
 
   const peripheral = state.selectedPeripherals[index];
+  if (peripheral.config?.pmicOwned) {
+    import("./pmic.js").then((module) => module.removePmicConfig());
+    return;
+  }
+
   const peripheralData = state.mcuData.socPeripherals.find((p) => p.id === id);
 
   const checkbox = document.getElementById(`${id.toLowerCase()}-checkbox`);
@@ -378,6 +383,12 @@ export function removePeripheral(id) {
 }
 
 export function editPeripheral(id) {
+  const selected = state.selectedPeripherals.find((p) => p.id === id);
+  if (selected?.config?.pmicOwned) {
+    import("./pmic.js").then((module) => module.openPmicModal());
+    return;
+  }
+
   const gpioPeripheral = state.selectedPeripherals.find(
     (p) => p.id === id && p.type === "GPIO",
   );
@@ -398,7 +409,6 @@ export function editPeripheral(id) {
     return;
   }
 
-  const selected = state.selectedPeripherals.find((p) => p.id === id);
   if (!selected) return;
   openPinSelectionModal(
     selected.peripheral,

--- a/js/pmic-data.js
+++ b/js/pmic-data.js
@@ -1,0 +1,258 @@
+// --- PMIC DEFINITIONS ---
+
+export const PMIC_DEFINITIONS = {
+  npm1300: {
+    id: "npm1300",
+    name: "nPM1300",
+    compatible: "nordic,npm1300",
+    address: "0x6b",
+    family: "npm13xx",
+    packageOptions: ["QFN", "CSP"],
+    headline: "Rechargeable Li-ion/Li-poly PMIC",
+    blurb:
+      "nPM1300 combines 32-800 mA battery charging, fuel-gauge telemetry, dual bucks, dual LDO/load switches, LEDs, GPIO, and watchdog support in a small package.",
+    badges: [
+      "32-800 mA charging",
+      "Fuel gauge",
+      "2 buck + 2 LDO",
+      "3 LEDs",
+      "Watchdog + hard reset",
+    ],
+    gpioCount: 5,
+    ledCount: 3,
+    regulators: [
+      { id: "BUCK1", label: "Buck 1", defaultVoltage: 1800000, kind: "buck" },
+      { id: "BUCK2", label: "Buck 2", defaultVoltage: 3300000, kind: "buck" },
+      {
+        id: "LDO1",
+        label: "LDO/Load switch 1",
+        defaultVoltage: 1800000,
+        kind: "ldo",
+      },
+      {
+        id: "LDO2",
+        label: "LDO/Load switch 2",
+        defaultVoltage: 1800000,
+        kind: "ldo",
+      },
+    ],
+    regulatorVoltage: { min: 1000000, max: 3300000, step: 100000 },
+    charger: {
+      current: { min: 32000, max: 800000, step: 2000, default: 150000 },
+      termMicrovolt: {
+        min: 4000000,
+        max: 4450000,
+        step: 50000,
+        default: 4200000,
+      },
+      vbusLimitMicroamp: {
+        min: 100000,
+        max: 1500000,
+        step: 100000,
+        default: 500000,
+      },
+      dischargeLimits: [200000, 1000000],
+      defaultDischargeLimit: 1000000,
+      termCurrentPercent: [10, 20],
+    },
+    fuelGaugeModels: {
+      kind: "secondary",
+      default: "custom",
+      note: "Use a Li-ion/Li-poly battery model generated with the nPM PowerUP app for accurate nRF Fuel Gauge results. The SDK nPM13xx fuel-gauge sample includes example battery_model.inc files for evaluation.",
+      options: [
+        {
+          id: "custom",
+          label: "Custom Li-ion/Li-poly model",
+          detail: "Recommended for production. Generate with nPM PowerUP.",
+        },
+        {
+          id: "sdk_sample",
+          label: "SDK sample model",
+          detail:
+            "Example only: nrf/samples/pmic/native/npm13xx_fuel_gauge/src/battery_model.inc",
+        },
+        {
+          id: "sdk_sample_20mah",
+          label: "SDK sample 20 mAh model",
+          detail:
+            "Example only: nrf/samples/pmic/native/npm13xx_fuel_gauge/src/battery_model_20mAh.inc",
+        },
+      ],
+    },
+  },
+  npm1304: {
+    id: "npm1304",
+    name: "nPM1304",
+    compatible: "nordic,npm1304",
+    address: "0x6b",
+    family: "npm13xx",
+    packageOptions: ["QFN", "CSP"],
+    headline: "Compact rechargeable PMIC",
+    blurb:
+      "nPM1304 targets smaller rechargeable designs with 4-100 mA charging, fuel-gauge telemetry, dual bucks, dual LDO/load switches, LEDs, GPIO, and watchdog support.",
+    badges: [
+      "4-100 mA charging",
+      "Fuel gauge",
+      "2 buck + 2 LDO",
+      "3 LEDs",
+      "Watchdog + hard reset",
+    ],
+    gpioCount: 5,
+    ledCount: 3,
+    regulators: [
+      { id: "BUCK1", label: "Buck 1", defaultVoltage: 1800000, kind: "buck" },
+      { id: "BUCK2", label: "Buck 2", defaultVoltage: 3300000, kind: "buck" },
+      {
+        id: "LDO1",
+        label: "LDO/Load switch 1",
+        defaultVoltage: 1800000,
+        kind: "ldo",
+      },
+      {
+        id: "LDO2",
+        label: "LDO/Load switch 2",
+        defaultVoltage: 1800000,
+        kind: "ldo",
+      },
+    ],
+    regulatorVoltage: { min: 1000000, max: 3300000, step: 100000 },
+    charger: {
+      current: { min: 4000, max: 100000, step: 500, default: 4000 },
+      termMicrovolt: {
+        min: 4000000,
+        max: 4650000,
+        step: 50000,
+        default: 4200000,
+      },
+      vbusLimitMicroamp: {
+        min: 100000,
+        max: 1500000,
+        step: 100000,
+        default: 500000,
+      },
+      dischargeLimits: [125000],
+      defaultDischargeLimit: 125000,
+      termCurrentPercent: [10, 5],
+    },
+    fuelGaugeModels: {
+      kind: "secondary",
+      default: "custom",
+      note: "Use a Li-ion/Li-poly battery model generated with the nPM PowerUP app for accurate nRF Fuel Gauge results. The SDK nPM13xx fuel-gauge sample includes example battery_model.inc files for evaluation.",
+      options: [
+        {
+          id: "custom",
+          label: "Custom Li-ion/Li-poly model",
+          detail: "Recommended for production. Generate with nPM PowerUP.",
+        },
+        {
+          id: "sdk_sample",
+          label: "SDK sample model",
+          detail:
+            "Example only: nrf/samples/pmic/native/npm13xx_fuel_gauge/src/battery_model.inc",
+        },
+        {
+          id: "sdk_sample_20mah",
+          label: "SDK sample 20 mAh model",
+          detail:
+            "Example only: nrf/samples/pmic/native/npm13xx_fuel_gauge/src/battery_model_20mAh.inc",
+        },
+      ],
+    },
+  },
+  npm2100: {
+    id: "npm2100",
+    name: "nPM2100",
+    compatible: "nordic,npm2100",
+    address: "0x74",
+    family: "npm2100",
+    packageOptions: ["QFN", "CSP"],
+    headline: "Primary-cell PMIC",
+    blurb:
+      "nPM2100 is for primary-cell designs, pairing boost regulation, an LDO/load switch, fuel-gauge telemetry, GPIO, and watchdog support in a small package.",
+    badges: [
+      "Primary cell",
+      "Fuel gauge",
+      "Boost + LDOSW",
+      "2 GPIO",
+      "Watchdog + hard reset",
+    ],
+    gpioCount: 2,
+    ledCount: 0,
+    regulators: [
+      { id: "BOOST", label: "Boost", defaultVoltage: 3300000, kind: "boost" },
+      {
+        id: "LDOSW",
+        label: "LDO/Load switch",
+        defaultVoltage: 1800000,
+        kind: "ldosw",
+      },
+    ],
+    regulatorVoltage: {
+      BOOST: { min: 1800000, max: 3300000, step: 50000 },
+      LDOSW: { min: 800000, max: 3000000, step: 50000 },
+    },
+    fuelGaugeModels: {
+      kind: "primary",
+      default: "alkaline_aa",
+      note: "nRF Fuel Gauge includes primary-cell battery profiles in nrfxlib/nrf_fuel_gauge/include/battery_models/primary_cell.",
+      options: [
+        {
+          id: "alkaline_aa",
+          label: "Alkaline AA",
+          kconfig: "CONFIG_BATTERY_MODEL_ALKALINE_AA",
+          include: "battery_models/primary_cell/AA_Alkaline.inc",
+        },
+        {
+          id: "alkaline_aaa",
+          label: "Alkaline AAA",
+          kconfig: "CONFIG_BATTERY_MODEL_ALKALINE_AAA",
+          include: "battery_models/primary_cell/AAA_Alkaline.inc",
+        },
+        {
+          id: "alkaline_2saa",
+          label: "2x alkaline AA in series",
+          kconfig: "CONFIG_BATTERY_MODEL_ALKALINE_2SAA",
+          include: "battery_models/primary_cell/2SAA_Alkaline.inc",
+        },
+        {
+          id: "alkaline_2saaa",
+          label: "2x alkaline AAA in series",
+          kconfig: "CONFIG_BATTERY_MODEL_ALKALINE_2SAAA",
+          include: "battery_models/primary_cell/2SAAA_Alkaline.inc",
+        },
+        {
+          id: "alkaline_lr44",
+          label: "Alkaline LR44 coin cell",
+          kconfig: "CONFIG_BATTERY_MODEL_ALKALINE_LR44",
+          include: "battery_models/primary_cell/LR44.inc",
+        },
+        {
+          id: "lithium_cr2032",
+          label: "Lithium CR2032 coin cell",
+          kconfig: "CONFIG_BATTERY_MODEL_LITHIUM_CR2032",
+          include: "battery_models/primary_cell/CR2032.inc",
+        },
+      ],
+    },
+  },
+};
+
+export function getPmicDefinition(id) {
+  return PMIC_DEFINITIONS[id] || null;
+}
+
+export function isNpm13xx(definitionOrConfig) {
+  const definition =
+    definitionOrConfig && definitionOrConfig.family
+      ? definitionOrConfig
+      : getPmicDefinition(definitionOrConfig?.id);
+  return definition?.family === "npm13xx";
+}
+
+export function getPmicBadgeText(config) {
+  const definition = getPmicDefinition(config?.id);
+  if (!definition) return "";
+
+  const i2cLabel = config.i2cPeripheralId || "I2C not set";
+  return `${definition.name} on ${i2cLabel}`;
+}

--- a/js/pmic.js
+++ b/js/pmic.js
@@ -1,0 +1,1391 @@
+// --- PMIC UI AND STATE MANAGEMENT ---
+
+import state from "./state.js";
+import { saveStateToLocalStorage } from "./state.js";
+import { updatePinDisplay } from "./pin-layout.js";
+import { updateSelectedPeripheralsList } from "./ui/selected-list.js";
+import { organizePeripherals } from "./peripherals.js";
+import { updateConsoleConfig } from "./console-config.js";
+import { enableScrollWheelSelectionForElement } from "./utils.js";
+import { PMIC_DEFINITIONS, getPmicDefinition, isNpm13xx } from "./pmic-data.js";
+
+const PMIC_USED_PIN_OWNER = "PMIC";
+const DEFAULT_THERMISTOR_OHMS = 10000;
+const DEFAULT_THERMISTOR_BETA = 3380;
+
+let tempPmicConfig = null;
+
+function formatMilliamps(microamps) {
+  const milliamps = microamps / 1000;
+  return Number.isInteger(milliamps)
+    ? `${milliamps} mA`
+    : `${milliamps.toFixed(1)} mA`;
+}
+
+function formatVolts(microvolts) {
+  return `${(microvolts / 1000000).toFixed(1)} V`;
+}
+
+function getI2cPeripherals() {
+  if (!Array.isArray(state.mcuData?.socPeripherals)) {
+    return [];
+  }
+
+  return state.mcuData.socPeripherals
+    .filter((peripheral) => {
+      const template = state.deviceTreeTemplates?.[peripheral.id];
+      return template?.type === "I2C";
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function getI2cPeripheral(id) {
+  return getI2cPeripherals().find((peripheral) => peripheral.id === id) || null;
+}
+
+function getSelectedI2cPeripheral(id) {
+  return (
+    state.selectedPeripherals.find(
+      (peripheral) => peripheral.id === id && peripheral.peripheral,
+    ) || null
+  );
+}
+
+function getDefaultI2cPeripheralId(previousConfig = null) {
+  if (previousConfig?.i2cPeripheralId) {
+    return previousConfig.i2cPeripheralId;
+  }
+
+  const selectedI2c = state.selectedPeripherals.find((peripheral) =>
+    getI2cPeripheral(peripheral.id),
+  );
+  if (selectedI2c) {
+    return selectedI2c.id;
+  }
+
+  return getI2cPeripherals()[0]?.id || "";
+}
+
+function buildDefaultRegulators(definition, previousConfig = null) {
+  const previousRegulators = previousConfig?.regulators || {};
+  const regulators = {};
+
+  definition.regulators.forEach((regulator, index) => {
+    const previous = previousRegulators[regulator.id] || {};
+    const enabledByDefault =
+      definition.id === "npm2100"
+        ? regulator.id === "BOOST"
+        : regulator.id === "BUCK1" || regulator.id === "BUCK2";
+
+    regulators[regulator.id] = {
+      enabled: previous.enabled ?? enabledByDefault,
+      voltageMicrovolt:
+        previous.voltageMicrovolt || regulator.defaultVoltage || 1800000,
+      boot: previous.boot || (enabledByDefault ? "boot-on" : "off"),
+      mode:
+        previous.mode ||
+        (regulator.kind === "ldo"
+          ? "ldo"
+          : regulator.kind === "boost"
+            ? "auto"
+            : "auto"),
+      gpioControl: {
+        enable: {
+          enabled: previous.gpioControl?.enable?.enabled || false,
+          pmicGpio: previous.gpioControl?.enable?.pmicGpio || "",
+          activeState:
+            previous.gpioControl?.enable?.activeState || "active-high",
+        },
+        pwm: {
+          enabled: previous.gpioControl?.pwm?.enabled || false,
+          pmicGpio: previous.gpioControl?.pwm?.pmicGpio || "",
+          activeState: previous.gpioControl?.pwm?.activeState || "active-low",
+        },
+        retention: {
+          enabled: previous.gpioControl?.retention?.enabled || false,
+          pmicGpio: previous.gpioControl?.retention?.pmicGpio || "",
+          activeState:
+            previous.gpioControl?.retention?.activeState || "active-high",
+        },
+        mode: {
+          enabled: previous.gpioControl?.mode?.enabled || false,
+          pmicGpio: previous.gpioControl?.mode?.pmicGpio || "",
+          activeState: previous.gpioControl?.mode?.activeState || "active-low",
+          forcedMode: previous.gpioControl?.mode?.forcedMode || "lp",
+        },
+      },
+      activeDischarge: previous.activeDischarge || false,
+    };
+  });
+
+  return regulators;
+}
+
+function buildDefaultDvsGpios(definition, previousConfig = null) {
+  const previous = previousConfig?.dvsGpios || {};
+  const pins = {};
+  for (let i = 0; i < definition.gpioCount; i += 1) {
+    pins[i] = {
+      enabled: previous[i]?.enabled || false,
+      hostPin: previous[i]?.hostPin || "",
+      activeState: previous[i]?.activeState || "active-high",
+    };
+  }
+  return pins;
+}
+
+function createDefaultPmicConfig(id, previousConfig = null) {
+  const definition = getPmicDefinition(id);
+  const previousForSamePart =
+    previousConfig?.id === id || !previousConfig ? previousConfig : null;
+
+  const config = {
+    id,
+    packageVariant:
+      previousForSamePart?.packageVariant || definition.packageOptions[0],
+    i2cPeripheralId: getDefaultI2cPeripheralId(previousConfig),
+    i2cPinFunctions: { ...(previousConfig?.i2cPinFunctions || {}) },
+    i2cOwned: Boolean(previousConfig?.i2cOwned),
+    hostInterrupt: {
+      enabled: previousForSamePart?.hostInterrupt?.enabled || false,
+      hostPin: previousForSamePart?.hostInterrupt?.hostPin || "",
+      activeState:
+        previousForSamePart?.hostInterrupt?.activeState || "active-high",
+      pmicPin:
+        previousForSamePart?.hostInterrupt?.pmicPin ??
+        (definition.family === "npm13xx" ? 3 : 0),
+    },
+    regulators: buildDefaultRegulators(definition, previousForSamePart),
+    dvsGpios: buildDefaultDvsGpios(definition, previousForSamePart),
+    gpioController: {
+      enabled: previousForSamePart?.gpioController?.enabled ?? true,
+    },
+    watchdog: {
+      enabled: previousForSamePart?.watchdog?.enabled ?? false,
+    },
+    fuelGauge: {
+      enabled: previousForSamePart?.fuelGauge?.enabled ?? true,
+      model:
+        previousForSamePart?.fuelGauge?.model ||
+        definition.fuelGaugeModels?.default ||
+        "custom",
+    },
+  };
+
+  if (isNpm13xx(definition)) {
+    config.charger = {
+      enabled: previousForSamePart?.charger?.enabled ?? true,
+      chargingEnable: previousForSamePart?.charger?.chargingEnable ?? true,
+      currentMicroamp:
+        previousForSamePart?.charger?.currentMicroamp ||
+        definition.charger.current.default,
+      termMicrovolt:
+        previousForSamePart?.charger?.termMicrovolt ||
+        definition.charger.termMicrovolt.default,
+      vbusLimitMicroamp:
+        previousForSamePart?.charger?.vbusLimitMicroamp ||
+        definition.charger.vbusLimitMicroamp.default,
+      dischargeLimitMicroamp:
+        previousForSamePart?.charger?.dischargeLimitMicroamp ||
+        definition.charger.defaultDischargeLimit,
+      termCurrentPercent:
+        previousForSamePart?.charger?.termCurrentPercent ||
+        definition.charger.termCurrentPercent[0],
+      thermistorOhms:
+        previousForSamePart?.charger?.thermistorOhms || DEFAULT_THERMISTOR_OHMS,
+      thermistorBeta:
+        previousForSamePart?.charger?.thermistorBeta || DEFAULT_THERMISTOR_BETA,
+    };
+    config.leds = {
+      enabled: previousForSamePart?.leds?.enabled ?? true,
+      modes: {
+        led0: previousForSamePart?.leds?.modes?.led0 || "error",
+        led1: previousForSamePart?.leds?.modes?.led1 || "charging",
+        led2: previousForSamePart?.leds?.modes?.led2 || "host",
+      },
+    };
+  }
+
+  return config;
+}
+
+function getSignalPin(config, signalName) {
+  return (
+    Object.entries(config.i2cPinFunctions || {}).find(
+      ([, signal]) => signal === signalName,
+    )?.[0] || ""
+  );
+}
+
+function sortGpioPins(pins) {
+  return [...pins].sort((a, b) => {
+    const aMatch = a.name.match(/P(\d+)\.(\d+)/);
+    const bMatch = b.name.match(/P(\d+)\.(\d+)/);
+    if (!aMatch || !bMatch) return a.name.localeCompare(b.name);
+
+    const aPort = parseInt(aMatch[1]);
+    const bPort = parseInt(bMatch[1]);
+    const aPin = parseInt(aMatch[2]);
+    const bPin = parseInt(bMatch[2]);
+    return aPort === bPort ? aPin - bPin : aPort - bPort;
+  });
+}
+
+function getPinsForI2cSignal(peripheral, signalName) {
+  const signal = peripheral?.signals?.find((s) => s.name === signalName);
+  if (!signal || !Array.isArray(state.mcuData?.pins)) {
+    return [];
+  }
+
+  const pins = state.mcuData.pins.filter((pin) => {
+    if (!pin.functions?.includes("Digital I/O")) return false;
+    if (signal.requiresClockCapablePin && !pin.isClockCapable) return false;
+
+    return signal.allowedGpio.some((allowed) =>
+      allowed.endsWith("*")
+        ? pin.port === allowed.slice(0, -1)
+        : pin.name === allowed,
+    );
+  });
+
+  return sortGpioPins(pins);
+}
+
+function getDigitalIoPins() {
+  if (!Array.isArray(state.mcuData?.pins)) {
+    return [];
+  }
+
+  return sortGpioPins(
+    state.mcuData.pins.filter((pin) => pin.functions?.includes("Digital I/O")),
+  );
+}
+
+function isPinUsedByOther(pinName, allowedOwners = []) {
+  const owner = state.usedPins[pinName]?.peripheral;
+  return Boolean(owner && !allowedOwners.includes(owner));
+}
+
+function pinOptions(pins, selectedPin, allowedOwners = [], excludePins = []) {
+  let html = '<option value="">-- Select pin --</option>';
+  pins.forEach((pin) => {
+    const isSelected = pin.name === selectedPin;
+    const disabled =
+      !isSelected &&
+      (excludePins.includes(pin.name) ||
+        isPinUsedByOther(pin.name, allowedOwners));
+    html += `<option value="${pin.name}" ${isSelected ? "selected" : ""} ${disabled ? "disabled" : ""}>${pin.name}${pin.isClockCapable ? " (Clock)" : ""}${disabled ? " (in use)" : ""}</option>`;
+  });
+  return html;
+}
+
+function rangeOptions(range, selectedValue, formatter) {
+  let html = "";
+  for (let value = range.min; value <= range.max; value += range.step) {
+    html += `<option value="${value}" ${value === selectedValue ? "selected" : ""}>${formatter(value)}</option>`;
+  }
+  return html;
+}
+
+function regulatorVoltageOptions(definition, regulator, selectedValue) {
+  const range =
+    definition.id === "npm2100"
+      ? definition.regulatorVoltage[regulator.id]
+      : definition.regulatorVoltage;
+  return rangeOptions(range, selectedValue, formatVolts);
+}
+
+function pmicGpioOptions(definition, selectedValue) {
+  let html = '<option value="">-- PMIC GPIO --</option>';
+  for (let i = 0; i < definition.gpioCount; i += 1) {
+    html += `<option value="${i}" ${String(i) === String(selectedValue) ? "selected" : ""}>GPIO${i}</option>`;
+  }
+  return html;
+}
+
+function activeStateOptions(selectedValue) {
+  return `
+    <option value="active-high" ${selectedValue !== "active-low" ? "selected" : ""}>Active high</option>
+    <option value="active-low" ${selectedValue === "active-low" ? "selected" : ""}>Active low</option>
+  `;
+}
+
+function renderRegulatorGpioControl(definition, regulator, controlName, label) {
+  const control =
+    tempPmicConfig.regulators[regulator.id].gpioControl?.[controlName] || {};
+  const forcedModeSelect =
+    definition.id === "npm2100" && controlName === "mode"
+      ? `<select data-regulator-control-forced-mode="${regulator.id}:${controlName}" ${control.enabled ? "" : "disabled"}>
+          ${getNpm2100ForcedModeOptions(regulator, control.forcedMode)}
+        </select>`
+      : "";
+
+  return `
+    <div class="pmic-control-row">
+      <label>
+        <input type="checkbox" data-regulator-control-enabled="${regulator.id}:${controlName}" ${control.enabled ? "checked" : ""} />
+        <span>${label}</span>
+      </label>
+      <select data-regulator-control-gpio="${regulator.id}:${controlName}" ${control.enabled ? "" : "disabled"}>
+        ${pmicGpioOptions(definition, control.pmicGpio)}
+      </select>
+      <select data-regulator-control-active="${regulator.id}:${controlName}" ${control.enabled ? "" : "disabled"}>
+        ${activeStateOptions(control.activeState)}
+      </select>
+      ${forcedModeSelect}
+    </div>
+  `;
+}
+
+function getNpm2100ForcedModeOptions(regulator, selectedValue) {
+  const options =
+    regulator.kind === "boost"
+      ? [
+          ["hp", "Force high power"],
+          ["lp", "Force low power"],
+          ["pass", "Force pass through"],
+          ["nohp", "Force no high power"],
+        ]
+      : [
+          ["hp", "Force high power"],
+          ["ulp", "Force ULP"],
+        ];
+
+  return options
+    .map(
+      ([value, label]) =>
+        `<option value="${value}" ${value === selectedValue ? "selected" : ""}>${label}</option>`,
+    )
+    .join("");
+}
+
+function renderPmicCard(definition) {
+  return `
+    <button type="button" class="pmic-card" data-pmic-id="${definition.id}">
+      <div class="pmic-card-top">
+        <strong>${definition.name}</strong>
+        <span>${definition.packageOptions.join(" / ")}</span>
+      </div>
+      <div class="pmic-card-headline">${definition.headline}</div>
+      <div class="pmic-badges">
+        ${definition.badges.map((badge) => `<span>${badge}</span>`).join("")}
+      </div>
+    </button>
+  `;
+}
+
+export function renderPmicPanel() {
+  const panel = document.getElementById("pmicPanel");
+  if (!panel) return;
+
+  const currentDefinition = getPmicDefinition(state.pmicConfig?.id);
+
+  if (currentDefinition) {
+    const regulatorCount = Object.values(
+      state.pmicConfig.regulators || {},
+    ).filter((regulator) => regulator.enabled).length;
+    const fuelGaugeModel = currentDefinition.fuelGaugeModels?.options.find(
+      (model) => model.id === state.pmicConfig.fuelGauge?.model,
+    );
+    const i2cPins = Object.entries(state.pmicConfig.i2cPinFunctions || {})
+      .map(([pin, signal]) => `${signal}: ${pin}`)
+      .join(", ");
+
+    panel.innerHTML = `
+      <div class="pmic-hero pmic-hero-selected">
+        <div>
+          <div class="pmic-eyebrow">Power plan</div>
+          <h3>${currentDefinition.name} added</h3>
+          <p>${currentDefinition.headline}</p>
+        </div>
+        <span class="pmic-chip">${state.pmicConfig.packageVariant}</span>
+      </div>
+      <div class="pmic-summary">
+        <div><strong>I2C:</strong> ${state.pmicConfig.i2cPeripheralId || "Not set"}</div>
+        <div><strong>Pins:</strong> ${i2cPins || "Using existing bus pins"}</div>
+        <div><strong>Regulators:</strong> ${regulatorCount} enabled</div>
+        <div><strong>Fuel gauge:</strong> ${
+          state.pmicConfig.fuelGauge?.enabled
+            ? fuelGaugeModel?.label || "enabled"
+            : "disabled"
+        }</div>
+      </div>
+      <div class="pmic-actions">
+        <button type="button" id="editPmicBtn">Edit PMIC</button>
+        <button type="button" id="removePmicBtn" class="secondary-btn">Remove</button>
+      </div>
+    `;
+
+    panel.querySelector("#editPmicBtn").addEventListener("click", () => {
+      openPmicModal(state.pmicConfig.id);
+    });
+    panel.querySelector("#removePmicBtn").addEventListener("click", () => {
+      removePmicConfig();
+    });
+    return;
+  }
+
+  panel.innerHTML = `
+    <div class="pmic-hero">
+      <div>
+        <div class="pmic-eyebrow">Board power</div>
+        <h3>Add a PMIC!</h3>
+        <p>Drop in a Nordic power companion with I2C pins, regulators, LEDs, GPIO, and fuel-gauge settings.</p>
+      </div>
+      <span class="pmic-chip">NEW</span>
+    </div>
+    <div class="pmic-card-grid">
+      ${Object.values(PMIC_DEFINITIONS).map(renderPmicCard).join("")}
+    </div>
+  `;
+
+  panel.querySelectorAll("[data-pmic-id]").forEach((button) => {
+    button.addEventListener("click", () =>
+      openPmicModal(button.dataset.pmicId),
+    );
+  });
+}
+
+export function openPmicModal(modelId = null) {
+  const requestedId = modelId || state.pmicConfig?.id || "npm1300";
+  tempPmicConfig =
+    state.pmicConfig?.id === requestedId
+      ? createDefaultPmicConfig(requestedId, state.pmicConfig)
+      : createDefaultPmicConfig(requestedId, tempPmicConfig);
+
+  renderPmicModal();
+  document.getElementById("pmicConfigModal").style.display = "flex";
+}
+
+export function closePmicModal() {
+  document.getElementById("pmicConfigModal").style.display = "none";
+  tempPmicConfig = null;
+}
+
+function renderPmicModal() {
+  const definition = getPmicDefinition(tempPmicConfig.id);
+  const body = document.getElementById("pmicModalBody");
+  const title = document.getElementById("pmicModalTitle");
+  title.textContent = `Configure ${definition.name}`;
+
+  body.innerHTML = `
+    <div class="pmic-modal-intro">
+      <strong>${definition.name}</strong>
+      <span>${definition.blurb}</span>
+    </div>
+    <div id="pmicError" class="validation-message" style="display: none"></div>
+
+    <div class="pmic-form-grid">
+      <div class="form-group">
+        <label for="pmicModelSelect">PMIC</label>
+        <select id="pmicModelSelect">
+          ${Object.values(PMIC_DEFINITIONS)
+            .map(
+              (pmic) =>
+                `<option value="${pmic.id}" ${pmic.id === definition.id ? "selected" : ""}>${pmic.name}</option>`,
+            )
+            .join("")}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="pmicPackageSelect">Package</label>
+        <select id="pmicPackageSelect">
+          ${definition.packageOptions
+            .map(
+              (pkg) =>
+                `<option value="${pkg}" ${pkg === tempPmicConfig.packageVariant ? "selected" : ""}>${pkg}</option>`,
+            )
+            .join("")}
+        </select>
+        <small>QFN and CSP are driver-equivalent here, but the board export records what is present.</small>
+      </div>
+    </div>
+
+    ${renderI2cSection(definition)}
+    ${renderHostInterruptSection(definition)}
+    ${renderDvsGpioSection(definition)}
+    ${renderRegulatorSection(definition)}
+    ${isNpm13xx(definition) ? renderChargerSection(definition) : renderNpm2100FuelGaugeSection()}
+    ${isNpm13xx(definition) ? renderLedSection(definition) : ""}
+    ${renderPmicFeatureSection(definition)}
+  `;
+
+  wirePmicModalEvents();
+}
+
+function renderI2cSection() {
+  const i2cPeripherals = getI2cPeripherals();
+  const selectedI2c = getSelectedI2cPeripheral(tempPmicConfig.i2cPeripheralId);
+  const selectedI2cIsPmicOwned = selectedI2c?.config?.pmicOwned === true;
+  const i2cPeripheral = getI2cPeripheral(tempPmicConfig.i2cPeripheralId);
+  const sclPin = getSignalPin(tempPmicConfig, "SCL");
+  const sdaPin = getSignalPin(tempPmicConfig, "SDA");
+  const canEditPins = !selectedI2c || selectedI2cIsPmicOwned;
+  const allowedOwners = [tempPmicConfig.i2cPeripheralId];
+
+  return `
+    <section class="pmic-config-section">
+      <h4>I2C connection</h4>
+      <div class="pmic-form-grid">
+        <div class="form-group">
+          <label for="pmicI2cSelect">I2C peripheral</label>
+          <select id="pmicI2cSelect">
+            <option value="">-- Select I2C --</option>
+            ${i2cPeripherals
+              .map(
+                (peripheral) =>
+                  `<option value="${peripheral.id}" ${peripheral.id === tempPmicConfig.i2cPeripheralId ? "selected" : ""}>${peripheral.id}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
+        <div class="form-group">
+          <label>I2C address</label>
+          <input type="text" value="${getPmicDefinition(tempPmicConfig.id).address}" disabled />
+        </div>
+      </div>
+      ${
+        !i2cPeripheral
+          ? `<div class="pmic-help">Select an I2C-capable peripheral first.</div>`
+          : canEditPins
+            ? `<div class="pmic-form-grid">
+                <div class="form-group">
+                  <label for="pmicSclPin">SCL pin</label>
+                  <select id="pmicSclPin">
+                    ${pinOptions(getPinsForI2cSignal(i2cPeripheral, "SCL"), sclPin, allowedOwners, [sdaPin].filter(Boolean))}
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label for="pmicSdaPin">SDA pin</label>
+                  <select id="pmicSdaPin">
+                    ${pinOptions(getPinsForI2cSignal(i2cPeripheral, "SDA"), sdaPin, allowedOwners, [sclPin].filter(Boolean))}
+                  </select>
+                </div>
+              </div>`
+            : `<div class="pmic-help">Using existing ${selectedI2c.id} pins: ${Object.entries(
+                selectedI2c.pinFunctions || {},
+              )
+                .map(([pin, signal]) => `${signal}: ${pin}`)
+                .join(", ")}</div>`
+      }
+    </section>
+  `;
+}
+
+function renderHostInterruptSection(definition) {
+  const host = tempPmicConfig.hostInterrupt || {};
+  const hostPins = getDigitalIoPins();
+  const sclPin = getSignalPin(tempPmicConfig, "SCL");
+  const sdaPin = getSignalPin(tempPmicConfig, "SDA");
+  const pmicPins = Array.from(
+    { length: definition.gpioCount },
+    (_, index) => index,
+  );
+
+  return `
+    <section class="pmic-config-section">
+      <h4>Interrupt</h4>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicHostInterruptEnabled" ${host.enabled ? "checked" : ""} />
+        Connect PMIC interrupt to host GPIO
+      </label>
+      <div class="pmic-form-grid">
+        <div class="form-group">
+          <label for="pmicHostPin">Host GPIO</label>
+          <select id="pmicHostPin" ${host.enabled ? "" : "disabled"}>
+            ${pinOptions(hostPins, host.hostPin || "", [PMIC_USED_PIN_OWNER], [sclPin, sdaPin].filter(Boolean))}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pmicPmicIntPin">PMIC INT pin</label>
+          <select id="pmicPmicIntPin" ${host.enabled ? "" : "disabled"}>
+            ${pmicPins
+              .map(
+                (pin) =>
+                  `<option value="${pin}" ${pin === host.pmicPin ? "selected" : ""}>GPIO${pin}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pmicHostActiveState">Active state</label>
+          <select id="pmicHostActiveState" ${host.enabled ? "" : "disabled"}>
+            <option value="active-high" ${host.activeState !== "active-low" ? "selected" : ""}>Active high</option>
+            <option value="active-low" ${host.activeState === "active-low" ? "selected" : ""}>Active low</option>
+          </select>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderDvsGpioSection(definition) {
+  const hostPins = getDigitalIoPins();
+  const sclPin = getSignalPin(tempPmicConfig, "SCL");
+  const sdaPin = getSignalPin(tempPmicConfig, "SDA");
+  const hostIntPin = tempPmicConfig.hostInterrupt?.hostPin || "";
+  const usedByDvs = Object.values(tempPmicConfig.dvsGpios || {})
+    .map((entry) => entry.hostPin)
+    .filter(Boolean);
+  const channels = Object.keys(tempPmicConfig.dvsGpios || {}).sort(
+    (a, b) => Number(a) - Number(b),
+  );
+
+  return `
+    <section class="pmic-config-section">
+      <h4>Regulator GPIO control lines</h4>
+      <div class="pmic-help">
+        Optional host GPIOs connected to PMIC GPIO inputs. Use these when an application will drive PMIC DVS state to enable a regulator, force PWM/PFM behavior, or switch retention/load-switch control.
+      </div>
+      <div class="pmic-dvs-grid">
+        ${channels
+          .map((channel) => {
+            const entry = tempPmicConfig.dvsGpios[channel];
+            const excludedPins = [
+              sclPin,
+              sdaPin,
+              hostIntPin,
+              ...usedByDvs.filter((pin) => pin !== entry.hostPin),
+            ].filter(Boolean);
+            return `
+              <div class="pmic-dvs-row">
+                <label>
+                  <input type="checkbox" data-dvs-enabled="${channel}" ${entry.enabled ? "checked" : ""} />
+                  <span>PMIC GPIO${channel}</span>
+                </label>
+                <select data-dvs-host-pin="${channel}" ${entry.enabled ? "" : "disabled"}>
+                  ${pinOptions(hostPins, entry.hostPin, [PMIC_USED_PIN_OWNER], excludedPins)}
+                </select>
+                <select data-dvs-active="${channel}" ${entry.enabled ? "" : "disabled"}>
+                  ${activeStateOptions(entry.activeState)}
+                </select>
+              </div>
+            `;
+          })
+          .join("")}
+      </div>
+    </section>
+  `;
+}
+
+function renderRegulatorSection(definition) {
+  return `
+    <section class="pmic-config-section">
+      <h4>Regulators</h4>
+      <div class="pmic-regulator-list">
+        ${definition.regulators
+          .map((regulator) => {
+            const config = tempPmicConfig.regulators[regulator.id];
+            const modeSelect =
+              regulator.kind === "ldo"
+                ? `<select data-regulator-mode="${regulator.id}">
+                    <option value="ldo" ${config.mode === "ldo" ? "selected" : ""}>LDO mode</option>
+                    <option value="ldsw" ${config.mode === "ldsw" ? "selected" : ""}>Load switch mode</option>
+                  </select>`
+                : regulator.kind === "buck"
+                  ? `<select data-regulator-mode="${regulator.id}">
+                    <option value="auto" ${config.mode === "auto" ? "selected" : ""}>Auto mode</option>
+                    <option value="pwm" ${config.mode === "pwm" ? "selected" : ""}>Force PWM</option>
+                    <option value="pfm" ${config.mode === "pfm" ? "selected" : ""}>Force PFM</option>
+                  </select>`
+                  : regulator.kind === "boost"
+                    ? `<select data-regulator-mode="${regulator.id}">
+                    <option value="auto" ${config.mode === "auto" ? "selected" : ""}>Auto mode</option>
+                    <option value="hp" ${config.mode === "hp" ? "selected" : ""}>High power</option>
+                    <option value="lp" ${config.mode === "lp" ? "selected" : ""}>Low power</option>
+                    <option value="pass" ${config.mode === "pass" ? "selected" : ""}>Pass through</option>
+                    <option value="nohp" ${config.mode === "nohp" ? "selected" : ""}>No high power</option>
+                  </select>`
+                    : regulator.kind === "ldosw"
+                      ? `<select data-regulator-mode="${regulator.id}">
+                    <option value="ldo-auto" ${config.mode === "ldo-auto" || config.mode === "auto" ? "selected" : ""}>LDO auto</option>
+                    <option value="ldo-hp" ${config.mode === "ldo-hp" ? "selected" : ""}>LDO high power</option>
+                    <option value="ldo-ulp" ${config.mode === "ldo-ulp" ? "selected" : ""}>LDO ultra-low power</option>
+                    <option value="ldsw-auto" ${config.mode === "ldsw-auto" ? "selected" : ""}>Load switch auto</option>
+                    <option value="ldsw-hp" ${config.mode === "ldsw-hp" ? "selected" : ""}>Load switch high power</option>
+                    <option value="ldsw-ulp" ${config.mode === "ldsw-ulp" ? "selected" : ""}>Load switch ultra-low power</option>
+                  </select>`
+                      : "";
+            const controlRows = isNpm13xx(definition)
+              ? [
+                  renderRegulatorGpioControl(
+                    definition,
+                    regulator,
+                    "enable",
+                    regulator.kind === "ldo"
+                      ? "GPIO enable/load-switch control"
+                      : "GPIO enable control",
+                  ),
+                  regulator.kind === "buck"
+                    ? renderRegulatorGpioControl(
+                        definition,
+                        regulator,
+                        "pwm",
+                        "GPIO force PWM/PFM control",
+                      )
+                    : "",
+                  regulator.kind === "buck"
+                    ? renderRegulatorGpioControl(
+                        definition,
+                        regulator,
+                        "retention",
+                        "GPIO retention-voltage control",
+                      )
+                    : "",
+                ].join("")
+              : renderRegulatorGpioControl(
+                  definition,
+                  regulator,
+                  "mode",
+                  "PMIC GPIO mode control",
+                );
+
+            return `
+              <div class="pmic-regulator-row">
+                <div class="pmic-regulator-main">
+                  <label>
+                    <input type="checkbox" data-regulator-enabled="${regulator.id}" ${config.enabled ? "checked" : ""} ${
+                      definition.id === "npm2100" && regulator.id === "BOOST"
+                        ? "disabled"
+                        : ""
+                    } />
+                    <span>${regulator.label}</span>
+                  </label>
+                  <select data-regulator-voltage="${regulator.id}">
+                    ${regulatorVoltageOptions(definition, regulator, config.voltageMicrovolt)}
+                  </select>
+                  <select data-regulator-boot="${regulator.id}">
+                    <option value="off" ${config.boot === "off" ? "selected" : ""}>Off at boot</option>
+                    <option value="boot-on" ${config.boot === "boot-on" ? "selected" : ""}>Boot on</option>
+                    <option value="always-on" ${config.boot === "always-on" ? "selected" : ""}>Always on</option>
+                  </select>
+                  ${modeSelect}
+                  <label class="pmic-inline-check">
+                    <input type="checkbox" data-regulator-active-discharge="${regulator.id}" ${config.activeDischarge ? "checked" : ""} />
+                    Active discharge
+                  </label>
+                </div>
+                <div class="pmic-regulator-controls">${controlRows}</div>
+              </div>
+            `;
+          })
+          .join("")}
+      </div>
+    </section>
+  `;
+}
+
+function renderChargerSection(definition) {
+  const charger = tempPmicConfig.charger;
+  const fuelGauge = tempPmicConfig.fuelGauge || {};
+  return `
+    <section class="pmic-config-section">
+      <h4>Charger and fuel gauge</h4>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicChargerEnabled" ${charger.enabled ? "checked" : ""} />
+        Add Zephyr charger sensor node
+      </label>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicChargingEnable" ${charger.chargingEnable ? "checked" : ""} ${charger.enabled ? "" : "disabled"} />
+        Enable battery charging
+      </label>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicFuelGaugeEnabled" ${fuelGauge.enabled ? "checked" : ""} />
+        Fuel-gauge telemetry available through the charger sensor
+      </label>
+      <div class="pmic-form-grid">
+        <div class="form-group">
+          <label for="pmicFuelGaugeModel">Fuel-gauge battery model</label>
+          <select id="pmicFuelGaugeModel" ${fuelGauge.enabled ? "" : "disabled"}>
+            ${definition.fuelGaugeModels.options
+              .map(
+                (model) =>
+                  `<option value="${model.id}" ${model.id === fuelGauge.model ? "selected" : ""}>${model.label}</option>`,
+              )
+              .join("")}
+          </select>
+          <small>${definition.fuelGaugeModels.note}</small>
+        </div>
+      </div>
+      <div class="pmic-form-grid">
+        <div class="form-group">
+          <label for="pmicChargeCurrent">Charge current</label>
+          <select id="pmicChargeCurrent" ${charger.enabled ? "" : "disabled"}>
+            ${rangeOptions(definition.charger.current, charger.currentMicroamp, formatMilliamps)}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pmicTermVoltage">Termination voltage</label>
+          <select id="pmicTermVoltage" ${charger.enabled ? "" : "disabled"}>
+            ${rangeOptions(definition.charger.termMicrovolt, charger.termMicrovolt, formatVolts)}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pmicVbusLimit">VBUS limit</label>
+          <select id="pmicVbusLimit" ${charger.enabled ? "" : "disabled"}>
+            ${rangeOptions(definition.charger.vbusLimitMicroamp, charger.vbusLimitMicroamp, formatMilliamps)}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pmicDischargeLimit">Discharge limit</label>
+          <select id="pmicDischargeLimit" ${charger.enabled ? "" : "disabled"}>
+            ${definition.charger.dischargeLimits
+              .map(
+                (limit) =>
+                  `<option value="${limit}" ${limit === charger.dischargeLimitMicroamp ? "selected" : ""}>${formatMilliamps(limit)}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pmicThermistorOhms">Thermistor</label>
+          <select id="pmicThermistorOhms" ${charger.enabled ? "" : "disabled"}>
+            ${[0, 10000, 47000, 100000]
+              .map(
+                (ohms) =>
+                  `<option value="${ohms}" ${ohms === charger.thermistorOhms ? "selected" : ""}>${ohms === 0 ? "None" : `${ohms / 1000} kOhm`}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="pmicThermistorBeta">Thermistor beta</label>
+          <input type="number" id="pmicThermistorBeta" value="${charger.thermistorBeta}" min="1" step="1" ${charger.enabled ? "" : "disabled"} />
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderNpm2100FuelGaugeSection() {
+  const definition = getPmicDefinition(tempPmicConfig.id);
+  const fuelGauge = tempPmicConfig.fuelGauge || {};
+  return `
+    <section class="pmic-config-section">
+      <h4>Fuel gauge</h4>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicFuelGaugeEnabled" ${fuelGauge.enabled ? "checked" : ""} />
+        Add nPM2100 VBAT sensor node
+      </label>
+      <div class="pmic-form-grid">
+        <div class="form-group">
+          <label for="pmicFuelGaugeModel">Primary-cell model</label>
+          <select id="pmicFuelGaugeModel" ${fuelGauge.enabled ? "" : "disabled"}>
+            ${definition.fuelGaugeModels.options
+              .map(
+                (model) =>
+                  `<option value="${model.id}" ${model.id === fuelGauge.model ? "selected" : ""}>${model.label}</option>`,
+              )
+              .join("")}
+          </select>
+          <small>${definition.fuelGaugeModels.note}</small>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderLedSection() {
+  const leds = tempPmicConfig.leds;
+  const modeOptions = (selected) =>
+    ["error", "charging", "host"]
+      .map(
+        (mode) =>
+          `<option value="${mode}" ${mode === selected ? "selected" : ""}>${mode}</option>`,
+      )
+      .join("");
+
+  return `
+    <section class="pmic-config-section">
+      <h4>LED outputs</h4>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicLedsEnabled" ${leds.enabled ? "checked" : ""} />
+        Add PMIC LED controller node
+      </label>
+      <div class="pmic-form-grid">
+        <div class="form-group">
+          <label for="pmicLed0Mode">LED0</label>
+          <select id="pmicLed0Mode" ${leds.enabled ? "" : "disabled"}>${modeOptions(leds.modes.led0)}</select>
+        </div>
+        <div class="form-group">
+          <label for="pmicLed1Mode">LED1</label>
+          <select id="pmicLed1Mode" ${leds.enabled ? "" : "disabled"}>${modeOptions(leds.modes.led1)}</select>
+        </div>
+        <div class="form-group">
+          <label for="pmicLed2Mode">LED2</label>
+          <select id="pmicLed2Mode" ${leds.enabled ? "" : "disabled"}>${modeOptions(leds.modes.led2)}</select>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderPmicFeatureSection(definition) {
+  return `
+    <section class="pmic-config-section">
+      <h4>PMIC GPIO and watchdog</h4>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicGpioEnabled" ${tempPmicConfig.gpioController?.enabled ? "checked" : ""} />
+        Add ${definition.gpioCount}-pin PMIC GPIO controller
+      </label>
+      <label class="pmic-checkbox-row">
+        <input type="checkbox" id="pmicWatchdogEnabled" ${tempPmicConfig.watchdog?.enabled ? "checked" : ""} />
+        Add PMIC watchdog node
+      </label>
+    </section>
+  `;
+}
+
+function wirePmicModalEvents() {
+  const selects = document.querySelectorAll("#pmicModalBody select");
+  selects.forEach((select) => enableScrollWheelSelectionForElement(select));
+
+  document.getElementById("pmicModelSelect").addEventListener("change", (e) => {
+    tempPmicConfig = createDefaultPmicConfig(
+      e.target.value,
+      readPmicConfigFromForm(),
+    );
+    renderPmicModal();
+  });
+
+  document.getElementById("pmicI2cSelect").addEventListener("change", () => {
+    tempPmicConfig = readPmicConfigFromForm();
+    tempPmicConfig.i2cPinFunctions = {};
+    renderPmicModal();
+  });
+
+  document
+    .getElementById("pmicHostInterruptEnabled")
+    .addEventListener("change", () => {
+      tempPmicConfig = readPmicConfigFromForm();
+      renderPmicModal();
+    });
+
+  const chargerEnabled = document.getElementById("pmicChargerEnabled");
+  if (chargerEnabled) {
+    chargerEnabled.addEventListener("change", () => {
+      tempPmicConfig = readPmicConfigFromForm();
+      renderPmicModal();
+    });
+  }
+
+  const ledsEnabled = document.getElementById("pmicLedsEnabled");
+  if (ledsEnabled) {
+    ledsEnabled.addEventListener("change", () => {
+      tempPmicConfig = readPmicConfigFromForm();
+      renderPmicModal();
+    });
+  }
+
+  const fuelGaugeEnabled = document.getElementById("pmicFuelGaugeEnabled");
+  if (fuelGaugeEnabled) {
+    fuelGaugeEnabled.addEventListener("change", () => {
+      tempPmicConfig = readPmicConfigFromForm();
+      renderPmicModal();
+    });
+  }
+
+  document.querySelectorAll("[data-dvs-enabled]").forEach((input) => {
+    input.addEventListener("change", () => {
+      tempPmicConfig = readPmicConfigFromForm();
+      renderPmicModal();
+    });
+  });
+
+  document
+    .querySelectorAll("[data-regulator-control-enabled]")
+    .forEach((input) => {
+      input.addEventListener("change", () => {
+        tempPmicConfig = readPmicConfigFromForm();
+        renderPmicModal();
+      });
+    });
+}
+
+function readPmicConfigFromForm() {
+  const id = document.getElementById("pmicModelSelect")?.value || "npm1300";
+  const definition = getPmicDefinition(id);
+  const config = createDefaultPmicConfig(id, tempPmicConfig);
+  config.packageVariant =
+    document.getElementById("pmicPackageSelect")?.value ||
+    config.packageVariant;
+  config.i2cPeripheralId =
+    document.getElementById("pmicI2cSelect")?.value || "";
+
+  const selectedI2c = getSelectedI2cPeripheral(config.i2cPeripheralId);
+  if (selectedI2c && selectedI2c.config?.pmicOwned !== true) {
+    config.i2cPinFunctions = { ...(selectedI2c.pinFunctions || {}) };
+    config.i2cOwned = false;
+  } else {
+    const sclPin = document.getElementById("pmicSclPin")?.value || "";
+    const sdaPin = document.getElementById("pmicSdaPin")?.value || "";
+    config.i2cPinFunctions = {};
+    if (sclPin) config.i2cPinFunctions[sclPin] = "SCL";
+    if (sdaPin) config.i2cPinFunctions[sdaPin] = "SDA";
+    config.i2cOwned = true;
+  }
+
+  config.hostInterrupt = {
+    enabled:
+      document.getElementById("pmicHostInterruptEnabled")?.checked || false,
+    hostPin: document.getElementById("pmicHostPin")?.value || "",
+    pmicPin: parseInt(document.getElementById("pmicPmicIntPin")?.value || "0"),
+    activeState:
+      document.getElementById("pmicHostActiveState")?.value || "active-high",
+  };
+
+  Object.keys(config.dvsGpios || {}).forEach((channel) => {
+    config.dvsGpios[channel] = {
+      enabled:
+        document.querySelector(`[data-dvs-enabled="${channel}"]`)?.checked ||
+        false,
+      hostPin:
+        document.querySelector(`[data-dvs-host-pin="${channel}"]`)?.value || "",
+      activeState:
+        document.querySelector(`[data-dvs-active="${channel}"]`)?.value ||
+        "active-high",
+    };
+  });
+
+  definition.regulators.forEach((regulator) => {
+    const enabled = document.querySelector(
+      `[data-regulator-enabled="${regulator.id}"]`,
+    );
+    const voltage = document.querySelector(
+      `[data-regulator-voltage="${regulator.id}"]`,
+    );
+    const boot = document.querySelector(
+      `[data-regulator-boot="${regulator.id}"]`,
+    );
+    const mode = document.querySelector(
+      `[data-regulator-mode="${regulator.id}"]`,
+    );
+    const previous = config.regulators[regulator.id];
+    const gpioControl = {
+      enable: readRegulatorGpioControl(regulator.id, "enable", previous),
+      pwm: readRegulatorGpioControl(regulator.id, "pwm", previous),
+      retention: readRegulatorGpioControl(regulator.id, "retention", previous),
+      mode: readRegulatorGpioControl(regulator.id, "mode", previous),
+    };
+
+    config.regulators[regulator.id] = {
+      enabled:
+        regulator.id === "BOOST" && definition.id === "npm2100"
+          ? true
+          : enabled?.checked || false,
+      voltageMicrovolt: parseInt(voltage?.value || previous.voltageMicrovolt),
+      boot: boot?.value || "off",
+      mode: mode?.value || previous.mode || "auto",
+      gpioControl,
+      activeDischarge:
+        document.querySelector(
+          `[data-regulator-active-discharge="${regulator.id}"]`,
+        )?.checked || false,
+    };
+  });
+
+  config.gpioController = {
+    enabled: document.getElementById("pmicGpioEnabled")?.checked || false,
+  };
+  config.watchdog = {
+    enabled: document.getElementById("pmicWatchdogEnabled")?.checked || false,
+  };
+  config.fuelGauge = {
+    enabled: document.getElementById("pmicFuelGaugeEnabled")?.checked || false,
+    model:
+      document.getElementById("pmicFuelGaugeModel")?.value ||
+      definition.fuelGaugeModels?.default ||
+      "custom",
+  };
+
+  if (isNpm13xx(definition)) {
+    config.charger = {
+      enabled: document.getElementById("pmicChargerEnabled")?.checked || false,
+      chargingEnable:
+        document.getElementById("pmicChargingEnable")?.checked || false,
+      currentMicroamp: parseInt(
+        document.getElementById("pmicChargeCurrent")?.value ||
+          definition.charger.current.default,
+      ),
+      termMicrovolt: parseInt(
+        document.getElementById("pmicTermVoltage")?.value ||
+          definition.charger.termMicrovolt.default,
+      ),
+      vbusLimitMicroamp: parseInt(
+        document.getElementById("pmicVbusLimit")?.value ||
+          definition.charger.vbusLimitMicroamp.default,
+      ),
+      dischargeLimitMicroamp: parseInt(
+        document.getElementById("pmicDischargeLimit")?.value ||
+          definition.charger.defaultDischargeLimit,
+      ),
+      termCurrentPercent: config.charger.termCurrentPercent,
+      thermistorOhms: parseInt(
+        document.getElementById("pmicThermistorOhms")?.value ||
+          DEFAULT_THERMISTOR_OHMS,
+      ),
+      thermistorBeta: parseInt(
+        document.getElementById("pmicThermistorBeta")?.value ||
+          DEFAULT_THERMISTOR_BETA,
+      ),
+    };
+    config.leds = {
+      enabled: document.getElementById("pmicLedsEnabled")?.checked || false,
+      modes: {
+        led0: document.getElementById("pmicLed0Mode")?.value || "error",
+        led1: document.getElementById("pmicLed1Mode")?.value || "charging",
+        led2: document.getElementById("pmicLed2Mode")?.value || "host",
+      },
+    };
+  }
+
+  return config;
+}
+
+function readRegulatorGpioControl(regulatorId, controlName, previousRegulator) {
+  const key = `${regulatorId}:${controlName}`;
+  const previous = previousRegulator?.gpioControl?.[controlName] || {};
+  return {
+    enabled:
+      document.querySelector(`[data-regulator-control-enabled="${key}"]`)
+        ?.checked || false,
+    pmicGpio:
+      document.querySelector(`[data-regulator-control-gpio="${key}"]`)?.value ||
+      "",
+    activeState:
+      document.querySelector(`[data-regulator-control-active="${key}"]`)
+        ?.value ||
+      previous.activeState ||
+      "active-high",
+    forcedMode:
+      document.querySelector(`[data-regulator-control-forced-mode="${key}"]`)
+        ?.value ||
+      previous.forcedMode ||
+      "lp",
+  };
+}
+
+function showPmicError(message) {
+  const error = document.getElementById("pmicError");
+  error.textContent = message;
+  error.style.display = "block";
+}
+
+function validatePmicConfig(config) {
+  const definition = getPmicDefinition(config.id);
+  if (!config.i2cPeripheralId || !getI2cPeripheral(config.i2cPeripheralId)) {
+    return "Select an I2C peripheral for the PMIC.";
+  }
+
+  const selectedI2c = getSelectedI2cPeripheral(config.i2cPeripheralId);
+  const i2cPinsEditable =
+    !selectedI2c || selectedI2c.config?.pmicOwned === true;
+  const sclPin = getSignalPin(config, "SCL");
+  const sdaPin = getSignalPin(config, "SDA");
+
+  if (i2cPinsEditable) {
+    if (!sclPin || !sdaPin) {
+      return "Select both SCL and SDA pins for the PMIC I2C bus.";
+    }
+    if (sclPin === sdaPin) {
+      return "SCL and SDA must use different pins.";
+    }
+    for (const pin of [sclPin, sdaPin]) {
+      if (isPinUsedByOther(pin, [config.i2cPeripheralId])) {
+        return `${pin} is already used by ${state.usedPins[pin].peripheral}.`;
+      }
+    }
+  }
+
+  const reservedPins = new Set([sclPin, sdaPin].filter(Boolean));
+
+  if (config.hostInterrupt.enabled) {
+    if (!config.hostInterrupt.hostPin) {
+      return "Select a host GPIO for the PMIC interrupt.";
+    }
+    if ([sclPin, sdaPin].includes(config.hostInterrupt.hostPin)) {
+      return "The PMIC interrupt cannot share the I2C pins.";
+    }
+    if (isPinUsedByOther(config.hostInterrupt.hostPin, [PMIC_USED_PIN_OWNER])) {
+      return `${config.hostInterrupt.hostPin} is already used by ${state.usedPins[config.hostInterrupt.hostPin].peripheral}.`;
+    }
+    reservedPins.add(config.hostInterrupt.hostPin);
+  }
+
+  const seenDvsHostPins = new Set();
+  for (const [channel, entry] of Object.entries(config.dvsGpios || {})) {
+    if (!entry.enabled) continue;
+
+    if (!entry.hostPin) {
+      return `Select a host GPIO for PMIC GPIO${channel}.`;
+    }
+    if (reservedPins.has(entry.hostPin)) {
+      return `PMIC GPIO${channel} cannot share another PMIC or I2C pin.`;
+    }
+    if (seenDvsHostPins.has(entry.hostPin)) {
+      return `${entry.hostPin} is already assigned to another PMIC GPIO control line.`;
+    }
+    if (isPinUsedByOther(entry.hostPin, [PMIC_USED_PIN_OWNER])) {
+      return `${entry.hostPin} is already used by ${state.usedPins[entry.hostPin].peripheral}.`;
+    }
+    seenDvsHostPins.add(entry.hostPin);
+  }
+
+  for (const [regulatorId, regulator] of Object.entries(
+    config.regulators || {},
+  )) {
+    const controls = regulator.gpioControl || {};
+    for (const [controlName, control] of Object.entries(controls)) {
+      if (!control.enabled) continue;
+
+      if (control.pmicGpio === "") {
+        return `${regulatorId} ${controlName} control needs a PMIC GPIO.`;
+      }
+      const channel = String(control.pmicGpio);
+      if (!config.dvsGpios?.[channel]?.enabled) {
+        return `${regulatorId} ${controlName} uses PMIC GPIO${channel}; enable its host control line above.`;
+      }
+    }
+  }
+
+  if (
+    isNpm13xx(definition) &&
+    config.fuelGauge?.enabled &&
+    !config.charger?.enabled
+  ) {
+    return "The nPM13xx fuel gauge is exposed through the charger sensor node; enable the charger sensor node.";
+  }
+
+  return null;
+}
+
+function clearPmicHostPins() {
+  Object.entries(state.usedPins).forEach(([pinName, usage]) => {
+    if (usage.peripheral === PMIC_USED_PIN_OWNER) {
+      delete state.usedPins[pinName];
+    }
+  });
+}
+
+function removeOwnedI2cPeripheral(config) {
+  if (!config?.i2cPeripheralId) return;
+
+  const index = state.selectedPeripherals.findIndex(
+    (peripheral) =>
+      peripheral.id === config.i2cPeripheralId &&
+      peripheral.config?.pmicOwned === true,
+  );
+  if (index === -1) return;
+
+  const peripheral = state.selectedPeripherals[index];
+  Object.keys(peripheral.pinFunctions || {}).forEach((pinName) => {
+    if (state.usedPins[pinName]?.peripheral === peripheral.id) {
+      delete state.usedPins[pinName];
+    }
+  });
+  if (peripheral.peripheral?.baseAddress) {
+    delete state.usedAddresses[peripheral.peripheral.baseAddress];
+  }
+  state.selectedPeripherals.splice(index, 1);
+}
+
+function ensurePmicI2cPeripheral(config) {
+  const existing = getSelectedI2cPeripheral(config.i2cPeripheralId);
+  if (existing) {
+    config.i2cOwned = existing.config?.pmicOwned === true;
+    config.i2cPinFunctions = { ...(existing.pinFunctions || {}) };
+    return;
+  }
+
+  const peripheral = getI2cPeripheral(config.i2cPeripheralId);
+  if (!peripheral) return;
+
+  state.selectedPeripherals.push({
+    id: peripheral.id,
+    peripheral,
+    pinFunctions: { ...config.i2cPinFunctions },
+    config: {
+      note: `PMIC ${getPmicDefinition(config.id).name}`,
+      pmicOwned: true,
+    },
+  });
+
+  Object.entries(config.i2cPinFunctions).forEach(([pinName, signalName]) => {
+    state.usedPins[pinName] = {
+      peripheral: peripheral.id,
+      function: signalName,
+      required: true,
+    };
+  });
+
+  if (peripheral.baseAddress) {
+    state.usedAddresses[peripheral.baseAddress] = peripheral.id;
+  }
+  config.i2cOwned = true;
+}
+
+function markPmicHostPins(config) {
+  if (config.hostInterrupt?.enabled && config.hostInterrupt.hostPin) {
+    state.usedPins[config.hostInterrupt.hostPin] = {
+      peripheral: PMIC_USED_PIN_OWNER,
+      function: "HOST_INT",
+      required: false,
+    };
+  }
+
+  Object.entries(config.dvsGpios || {}).forEach(([channel, entry]) => {
+    if (!entry.enabled || !entry.hostPin) return;
+
+    state.usedPins[entry.hostPin] = {
+      peripheral: PMIC_USED_PIN_OWNER,
+      function: `PMIC_GPIO${channel}`,
+      required: false,
+    };
+  });
+}
+
+export function confirmPmicConfig() {
+  const config = readPmicConfigFromForm();
+  const validationError = validatePmicConfig(config);
+  if (validationError) {
+    showPmicError(validationError);
+    return;
+  }
+
+  clearPmicHostPins();
+  removeOwnedI2cPeripheral(state.pmicConfig);
+  ensurePmicI2cPeripheral(config);
+  markPmicHostPins(config);
+
+  state.pmicConfig = config;
+
+  renderPmicPanel();
+  organizePeripherals();
+  updateSelectedPeripheralsList();
+  updatePinDisplay();
+  updateConsoleConfig();
+  saveStateToLocalStorage();
+  closePmicModal();
+}
+
+export function removePmicConfig() {
+  clearPmicHostPins();
+  removeOwnedI2cPeripheral(state.pmicConfig);
+  state.pmicConfig = null;
+
+  renderPmicPanel();
+  organizePeripherals();
+  updateSelectedPeripheralsList();
+  updatePinDisplay();
+  updateConsoleConfig();
+  saveStateToLocalStorage();
+}
+
+export function handlePmicOwnedI2cRemoval(peripheralId) {
+  if (state.pmicConfig?.i2cPeripheralId === peripheralId) {
+    removePmicConfig();
+    return true;
+  }
+
+  return false;
+}

--- a/js/state.js
+++ b/js/state.js
@@ -12,6 +12,7 @@ const state = {
   boardInfo: null,
   consoleUart: null, // Peripheral ID (e.g., "UARTE20") of selected console UART, or null for RTT
   devkitConfig: null, // Loaded devkit config, or null for custom board
+  pmicConfig: null, // Selected PMIC configuration, or null when no PMIC is present
 };
 
 export default state;
@@ -87,14 +88,49 @@ export function saveStateToLocalStorage() {
   const config = {
     selectedPeripherals: state.selectedPeripherals.map(serializePeripheral),
     consoleUart: state.consoleUart,
+    pmicConfig: state.pmicConfig,
   };
   localStorage.setItem(key, JSON.stringify(config));
 }
 
-export function applyConfig(config) {
-  if (!config || !config.selectedPeripherals) return;
+function cloneConfig(config) {
+  return config ? JSON.parse(JSON.stringify(config)) : null;
+}
 
-  for (const p_config of config.selectedPeripherals) {
+function markPmicPinsFromConfig(config) {
+  if (!config) return;
+
+  if (config.hostInterrupt?.enabled && config.hostInterrupt.hostPin) {
+    state.usedPins[config.hostInterrupt.hostPin] = {
+      peripheral: "PMIC",
+      function: "HOST_INT",
+      required: false,
+    };
+  }
+
+  Object.entries(config.dvsGpios || {}).forEach(([channel, entry]) => {
+    if (!entry.enabled || !entry.hostPin) return;
+
+    state.usedPins[entry.hostPin] = {
+      peripheral: "PMIC",
+      function: `PMIC_GPIO${channel}`,
+      required: false,
+    };
+  });
+}
+
+function clearPmicPins() {
+  Object.entries(state.usedPins).forEach(([pinName, usage]) => {
+    if (usage.peripheral === "PMIC") {
+      delete state.usedPins[pinName];
+    }
+  });
+}
+
+export function applyConfig(config) {
+  if (!config) return;
+
+  for (const p_config of config.selectedPeripherals || []) {
     if (p_config.type === "GPIO") {
       state.selectedPeripherals.push({
         id: p_config.id,
@@ -159,6 +195,7 @@ export function applyConfig(config) {
           id: p_data.id,
           peripheral: p_data,
           pinFunctions: p_config.pinFunctions,
+          config: p_config.config || {},
         });
         for (const pinName in p_config.pinFunctions) {
           const signal = p_data.signals.find(
@@ -176,6 +213,10 @@ export function applyConfig(config) {
       }
     }
   }
+
+  clearPmicPins();
+  state.pmicConfig = cloneConfig(config.pmicConfig);
+  markPmicPinsFromConfig(state.pmicConfig);
 }
 
 export function loadStateFromLocalStorage() {
@@ -205,6 +246,7 @@ export function resetState() {
   state.usedAddresses = {};
   state.consoleUart = null;
   state.devkitConfig = null;
+  state.pmicConfig = null;
   document
     .querySelectorAll('input[type="checkbox"][data-peripheral-id]')
     .forEach((cb) => {

--- a/js/ui/import-export.js
+++ b/js/ui/import-export.js
@@ -12,6 +12,7 @@ import { organizePeripherals } from "../peripherals.js";
 import { updatePinDisplay } from "../pin-layout.js";
 import { updateSelectedPeripheralsList } from "./selected-list.js";
 import { updateConsoleConfig } from "../console-config.js";
+import { renderPmicPanel } from "../pmic.js";
 
 let pendingImportConfig = null;
 let isExportMode = true;
@@ -97,7 +98,9 @@ function validateAndShowImportModal(config) {
   text.textContent = `This will import a pin configuration from the file. The configuration is for:`;
   bullet1.innerHTML = `<strong>MCU:</strong> ${config.mcu}`;
   bullet2.innerHTML = `<strong>Package:</strong> ${config.package}`;
-  bullet3.innerHTML = `<strong>Peripherals:</strong> ${config.selectedPeripherals.length} configured`;
+  bullet3.innerHTML = `<strong>Peripherals:</strong> ${
+    config.selectedPeripherals.length + (config.pmicConfig ? 1 : 0)
+  } configured`;
 
   if (isDifferentPart) {
     warning.style.backgroundColor = "#fff3cd";
@@ -162,6 +165,8 @@ function exportConfig() {
     mcu: mcu,
     package: pkg,
     selectedPeripherals: state.selectedPeripherals.map(serializePeripheral),
+    consoleUart: state.consoleUart,
+    pmicConfig: state.pmicConfig,
   };
 
   const json = JSON.stringify(config, null, 2);
@@ -218,11 +223,14 @@ async function importConfig() {
 
   applyConfig({
     selectedPeripherals: config.selectedPeripherals,
+    pmicConfig: config.pmicConfig,
   });
 
+  state.consoleUart = config.consoleUart || null;
   saveStateToLocalStorage();
 
   organizePeripherals();
+  renderPmicPanel();
   updateSelectedPeripheralsList();
   updatePinDisplay();
   updateConsoleConfig();

--- a/js/ui/selected-list.js
+++ b/js/ui/selected-list.js
@@ -2,12 +2,17 @@
 
 import state from "../state.js";
 import { removePeripheral, editPeripheral } from "../peripherals.js";
+import { getPmicDefinition } from "../pmic-data.js";
 
 export function updateSelectedPeripheralsList() {
   const selectedList = document.getElementById("selectedList");
   selectedList.innerHTML = "";
 
-  if (state.selectedPeripherals.length === 0) {
+  let visiblePeripherals = state.selectedPeripherals.filter(
+    (peripheral) => peripheral.config?.pmicOwned !== true,
+  );
+
+  if (visiblePeripherals.length === 0 && !state.pmicConfig) {
     selectedList.innerHTML =
       '<li class="empty-message">No peripherals selected yet.</li>';
     return;
@@ -28,7 +33,15 @@ export function updateSelectedPeripheralsList() {
     uniquePeripherals.forEach((p) => state.selectedPeripherals.push(p));
   }
 
-  state.selectedPeripherals.forEach((p) => {
+  visiblePeripherals = state.selectedPeripherals.filter(
+    (peripheral) => peripheral.config?.pmicOwned !== true,
+  );
+
+  if (state.pmicConfig) {
+    selectedList.appendChild(createPmicSelectedItem());
+  }
+
+  visiblePeripherals.forEach((p) => {
     const item = document.createElement("li");
     item.className = "selected-item";
 
@@ -107,4 +120,43 @@ export function updateSelectedPeripheralsList() {
     item.addEventListener("click", () => editPeripheral(p.id));
     selectedList.appendChild(item);
   });
+}
+
+function createPmicSelectedItem() {
+  const definition = getPmicDefinition(state.pmicConfig.id);
+  const item = document.createElement("li");
+  item.className = "selected-item";
+
+  const regulatorCount = Object.values(
+    state.pmicConfig.regulators || {},
+  ).filter((regulator) => regulator.enabled).length;
+  const fuelGaugeModel = definition?.fuelGaugeModels?.options.find(
+    (model) => model.id === state.pmicConfig.fuelGauge?.model,
+  );
+  const i2cPins = Object.entries(state.pmicConfig.i2cPinFunctions || {})
+    .map(([pin, signal]) => `${signal}: ${pin}`)
+    .join(", ");
+
+  item.innerHTML = `
+    <div>
+      <strong>PMIC: ${definition?.name || state.pmicConfig.id}</strong>
+      <div>${state.pmicConfig.i2cPeripheralId || "I2C not set"}${i2cPins ? ` (${i2cPins})` : ""}; ${regulatorCount} regulators; ${
+        state.pmicConfig.fuelGauge?.enabled
+          ? fuelGaugeModel?.label || "fuel gauge"
+          : "fuel gauge off"
+      }</div>
+    </div>
+    <button class="remove-btn" data-id="PMIC">Remove</button>
+  `;
+
+  item.querySelector(".remove-btn").addEventListener("click", (event) => {
+    event.stopPropagation();
+    import("../pmic.js").then((module) => module.removePmicConfig());
+  });
+
+  item.addEventListener("click", () => {
+    import("../pmic.js").then((module) => module.openPmicModal());
+  });
+
+  return item;
 }

--- a/style.css
+++ b/style.css
@@ -148,6 +148,86 @@ a:hover {
   font-size: 0.85rem;
 }
 
+.pmic-feature-callout {
+  align-items: center;
+  animation: pmic-callout-glow 1s ease-out 0.35s 1;
+  appearance: none;
+  background:
+    linear-gradient(90deg, rgba(122, 214, 230, 0.2), transparent 58%),
+    var(--card-bg);
+  border: 1px solid rgba(122, 214, 230, 0.5);
+  border-radius: 8px;
+  color: var(--text-color);
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 1rem;
+  justify-content: space-between;
+  margin: -0.5rem 0 1.25rem;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
+  width: 100%;
+}
+
+.pmic-feature-callout:hover,
+.pmic-feature-callout:focus-visible {
+  border-color: var(--primary-hover);
+  box-shadow: 0 0 0 3px rgba(122, 214, 230, 0.16);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.pmic-feature-text {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.75rem;
+}
+
+.pmic-feature-text strong {
+  color: var(--primary-hover);
+  font-size: 1.1rem;
+  line-height: 1.2;
+}
+
+.pmic-feature-text span:last-child {
+  color: var(--light-text);
+  font-size: 0.9rem;
+}
+
+body.dark-mode .pmic-feature-callout {
+  background:
+    linear-gradient(90deg, rgba(45, 212, 191, 0.14), transparent 58%),
+    var(--card-bg);
+}
+
+@keyframes pmic-callout-glow {
+  0% {
+    border-color: rgba(122, 214, 230, 0.5);
+    box-shadow: 0 0 0 rgba(122, 214, 230, 0);
+  }
+  35% {
+    border-color: var(--primary-hover);
+    box-shadow:
+      0 0 0 4px rgba(122, 214, 230, 0.18),
+      0 0 28px rgba(122, 214, 230, 0.45);
+  }
+  100% {
+    border-color: rgba(122, 214, 230, 0.5);
+    box-shadow: 0 0 0 rgba(122, 214, 230, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pmic-feature-callout {
+    animation: none;
+  }
+}
+
 .github-link {
   display: flex;
   align-items: center;
@@ -769,6 +849,7 @@ option:disabled {
 }
 
 .form-group input[type="text"],
+.form-group input[type="number"],
 .form-group textarea,
 .form-group select {
   width: 100%;
@@ -782,6 +863,7 @@ option:disabled {
 }
 
 .form-group input[type="text"]:focus,
+.form-group input[type="number"]:focus,
 .form-group textarea:focus,
 .form-group select:focus {
   outline: none;
@@ -888,6 +970,265 @@ option:disabled {
   box-shadow: 0 0 0 2px rgba(217, 83, 79, 0.2) !important;
 }
 
+/* --- PMIC CONFIGURATION --- */
+.pmic-panel {
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+}
+
+.pmic-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(122, 214, 230, 0.45);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(122, 214, 230, 0.15), transparent 55%),
+    var(--bg-color);
+}
+
+.pmic-hero h3 {
+  margin: 0.15rem 0;
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
+.pmic-hero p {
+  color: var(--light-text);
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.pmic-hero-selected {
+  border-color: rgba(91, 192, 222, 0.55);
+  background:
+    linear-gradient(135deg, rgba(91, 192, 222, 0.18), transparent 60%),
+    var(--bg-color);
+}
+
+.pmic-eyebrow {
+  color: var(--primary-hover);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pmic-chip,
+.pmic-badges span {
+  align-self: flex-start;
+  border-radius: 999px;
+  border: 1px solid rgba(240, 173, 78, 0.5);
+  background-color: rgba(240, 173, 78, 0.13);
+  color: var(--warning-color);
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  white-space: nowrap;
+}
+
+.pmic-card-grid {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.pmic-card {
+  width: 100%;
+  background-color: var(--secondary-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-color);
+  cursor: pointer;
+  padding: 0.85rem;
+  text-align: left;
+}
+
+.pmic-card:hover {
+  background-color: var(--border-color);
+}
+
+.pmic-card-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+
+.pmic-card-top span {
+  color: var(--light-text);
+  font-size: 0.8rem;
+}
+
+.pmic-card-headline {
+  color: var(--primary-hover);
+  font-size: 0.85rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+}
+
+.pmic-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.7rem;
+}
+
+.pmic-summary {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.86rem;
+  margin: 0.8rem 0;
+}
+
+.pmic-actions {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+}
+
+#pmicConfigModal {
+  align-items: center;
+  box-sizing: border-box;
+  justify-content: center;
+  padding: 1rem;
+}
+
+#pmicModalBody {
+  overflow-y: auto;
+  padding: 1.5rem 2rem;
+}
+
+.pmic-modal-content {
+  margin: 0;
+  max-width: 980px;
+  max-height: calc(100vh - 2rem);
+}
+
+.pmic-modal-intro {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.pmic-modal-intro span,
+.pmic-help {
+  color: var(--light-text);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.pmic-config-section {
+  border-top: 1px solid var(--border-color);
+  padding: 1rem 0;
+}
+
+.pmic-config-section h4 {
+  font-size: 0.95rem;
+  margin: 0 0 0.75rem 0;
+}
+
+.pmic-form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.pmic-checkbox-row,
+.pmic-inline-check {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.pmic-dvs-grid,
+.pmic-regulator-list {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.75rem;
+}
+
+.pmic-dvs-row,
+.pmic-control-row,
+.pmic-regulator-main {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.pmic-dvs-row {
+  grid-template-columns: minmax(130px, 0.75fr) minmax(150px, 1fr) minmax(
+      125px,
+      0.75fr
+    );
+}
+
+.pmic-regulator-row {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 0.85rem;
+}
+
+.pmic-regulator-main {
+  grid-template-columns:
+    minmax(130px, 1fr) minmax(120px, 0.8fr) minmax(110px, 0.75fr)
+    minmax(130px, 0.9fr) minmax(120px, 0.8fr);
+}
+
+.pmic-regulator-controls {
+  border-top: 1px dashed var(--border-color);
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+}
+
+.pmic-control-row {
+  grid-template-columns:
+    minmax(190px, 1.1fr) minmax(120px, 0.7fr) minmax(120px, 0.7fr)
+    minmax(150px, 0.8fr);
+}
+
+.pmic-control-row select:last-child:nth-child(4) {
+  grid-column: auto;
+}
+
+.pmic-control-row label,
+.pmic-dvs-row label,
+.pmic-regulator-main label {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.validation-message {
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  border-radius: 6px;
+  color: #721c24;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+}
+
+body.dark-mode .pmic-hero,
+body.dark-mode .pmic-hero-selected {
+  background:
+    linear-gradient(135deg, rgba(45, 212, 191, 0.12), transparent 60%),
+    var(--bg-color);
+}
+
+body.dark-mode .validation-message {
+  background-color: rgba(229, 115, 115, 0.2);
+  border-color: rgba(229, 115, 115, 0.3);
+  color: #e57373;
+}
+
 /* --- RESPONSIVE DESIGN --- */
 
 /* Desktop (default): 3-column grid - already defined as 380px 1fr 380px */
@@ -905,6 +1246,12 @@ option:disabled {
 /* Small tablet (<900px): single column */
 @media (max-width: 899px) {
   .content-grid {
+    grid-template-columns: 1fr;
+  }
+  .pmic-form-grid,
+  .pmic-dvs-row,
+  .pmic-regulator-main,
+  .pmic-control-row {
     grid-template-columns: 1fr;
   }
 }
@@ -927,6 +1274,10 @@ option:disabled {
   }
   .footer .github-link {
     justify-self: center;
+  }
+  .pmic-feature-callout {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add single-PMIC configuration support for nPM1300, nPM1304, and nPM2100
- Add PMIC UI with an above-the-fold clickable callout, short PMIC cards, watchdog/reset badge, fuel-gauge model guidance, and centered configuration modal
- Generate Zephyr DeviceTree/Kconfig exports for PMIC I2C nodes, regulators, charger/fuel gauge, LEDs, GPIO controller, watchdog, DVS GPIO controls, load-switch modes, and forced power modes
- Persist/import/export PMIC config and hide PMIC-owned I2C buses from the normal selected-peripheral list

## Verification
- npm run format
- npm test
- Browser smoke via Playwright using local http://127.0.0.1:8000